### PR TITLE
[GRAY-87] Java SDK hooks impl and source metdata addn

### DIFF
--- a/clients/java/client-api/src/main/java/com/flipkart/grayskull/spi/HostIdentityProvider.java
+++ b/clients/java/client-api/src/main/java/com/flipkart/grayskull/spi/HostIdentityProvider.java
@@ -1,0 +1,36 @@
+package com.flipkart.grayskull.spi;
+
+/**
+ * SPI for supplying a string that identifies the host running the Grayskull
+ * client, sent to the server as the {@code X-Grayskull-Host-Identification}
+ * header on data-plane calls ({@code getSecret} and the batch-poll endpoint).
+ * <p>
+ * The OSS distribution ships a hostname-based default implementation. Consumers
+ * that need stronger, verifiable identity (e.g. a Kubernetes service-account
+ * token signed by the cluster) can provide their own implementation and pass it
+ * into the client at construction time.
+ * <p>
+ * <b>Contract:</b>
+ * <ul>
+ *   <li>Implementations MUST be thread-safe; {@link #getHostIdentification()}
+ *       may be invoked from multiple threads concurrently on every request.</li>
+ *   <li>Implementations MUST be fast (treat it like reading a cached value);
+ *       anything expensive should be cached internally.</li>
+ *   <li>Implementations MUST NOT return {@code null}; they should return an empty
+ *       string if no identity can be determined, in which case the SDK will
+ *       omit the header. Returning a non-empty value causes the SDK to send
+ *       it verbatim as the header value.</li>
+ *   <li>Returned values MUST NOT contain CR/LF characters (HTTP header-injection
+ *       guard); the SDK will sanitise defensively, but callers should not rely
+ *       on that.</li>
+ * </ul>
+ */
+@FunctionalInterface
+public interface HostIdentityProvider {
+
+    /**
+     * Returns the identity string to send on data-plane calls, or an empty string
+     * when no identity is available. Never {@code null}.
+     */
+    String getHostIdentification();
+}

--- a/clients/java/client-impl/pom.xml
+++ b/clients/java/client-impl/pom.xml
@@ -94,4 +94,23 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>META-INF/grayskull-client.properties</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>META-INF/grayskull-client.properties</exclude>
+                </excludes>
+            </resource>
+        </resources>
+    </build>
+
 </project>

--- a/clients/java/client-impl/src/main/java/com/flipkart/grayskull/GrayskullClientImpl.java
+++ b/clients/java/client-impl/src/main/java/com/flipkart/grayskull/GrayskullClientImpl.java
@@ -6,15 +6,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import com.flipkart.grayskull.auth.GrayskullAuthHeaderProvider;
 import com.flipkart.grayskull.constants.MDCKeys;
-import com.flipkart.grayskull.metrics.MetricsPublisher;
-import com.flipkart.grayskull.models.GrayskullClientConfiguration;
-import com.flipkart.grayskull.models.response.HttpResponse;
-import com.flipkart.grayskull.models.SecretValue;
-import com.flipkart.grayskull.models.exceptions.GrayskullException;
-import com.flipkart.grayskull.hooks.NoOpRefreshHandlerRef;
+import com.flipkart.grayskull.hooks.ActiveRefreshHandlerRef;
 import com.flipkart.grayskull.hooks.RefreshHandlerRef;
 import com.flipkart.grayskull.hooks.SecretRefreshHook;
+import com.flipkart.grayskull.metrics.MetricsPublisher;
+import com.flipkart.grayskull.models.GrayskullClientConfiguration;
+import com.flipkart.grayskull.models.SecretValue;
+import com.flipkart.grayskull.models.exceptions.GrayskullException;
+import com.flipkart.grayskull.models.response.HttpResponse;
 import com.flipkart.grayskull.models.response.Response;
+import com.flipkart.grayskull.spi.DefaultHostIdentityProvider;
+import com.flipkart.grayskull.spi.HostIdentityProvider;
 import okhttp3.HttpUrl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,43 +34,62 @@ import java.util.concurrent.TimeUnit;
  */
 public final class GrayskullClientImpl implements GrayskullClient {
     private static final Logger log = LoggerFactory.getLogger(GrayskullClientImpl.class);
-    private static final TypeReference<Response<SecretValue>> SECRET_VALUE_TYPE_REFERENCE = 
+    private static final TypeReference<Response<SecretValue>> SECRET_VALUE_TYPE_REFERENCE =
             new TypeReference<Response<SecretValue>>() {};
-    
+
     private final String baseUrl;
-    private final GrayskullAuthHeaderProvider authHeaderProvider;
-    private final GrayskullClientConfiguration grayskullClientConfiguration;
     private final GrayskullHttpClient httpClient;
     private final ObjectMapper objectMapper;
+    private final SecretRefreshManager refreshManager;
+
+    /**
+     * Creates a new Grayskull client with the default {@link HostIdentityProvider}
+     * (hostname-based, OSS-friendly). For stronger identity (e.g. K8s SA token),
+     * use the overload that accepts a custom provider.
+     */
+    public GrayskullClientImpl(GrayskullAuthHeaderProvider authHeaderProvider,
+                               GrayskullClientConfiguration grayskullClientConfiguration) {
+        this(authHeaderProvider, grayskullClientConfiguration, new DefaultHostIdentityProvider());
+    }
 
     /**
      * Creates a new Grayskull client implementation.
      *
-     * @param authHeaderProvider provider for authentication headers (must not be null)
+     * @param authHeaderProvider           provider for authentication headers (must not be null)
      * @param grayskullClientConfiguration configuration properties (must not be null)
-     * @throws IllegalArgumentException if authHeaderProvider or grayskullClientConfiguration is null
+     * @param hostIdentityProvider         provider for the host-identification header (must not be null)
+     * @throws IllegalArgumentException if any argument is null
      */
-    public GrayskullClientImpl(GrayskullAuthHeaderProvider authHeaderProvider, GrayskullClientConfiguration grayskullClientConfiguration) {
-        
+    public GrayskullClientImpl(GrayskullAuthHeaderProvider authHeaderProvider,
+                               GrayskullClientConfiguration grayskullClientConfiguration,
+                               HostIdentityProvider hostIdentityProvider) {
+
         if (authHeaderProvider == null) {
             throw new IllegalArgumentException("authHeaderProvider cannot be null");
         }
         if (grayskullClientConfiguration == null) {
             throw new IllegalArgumentException("grayskullClientConfiguration cannot be null");
         }
-        
+        if (hostIdentityProvider == null) {
+            throw new IllegalArgumentException("hostIdentityProvider cannot be null");
+        }
+
         this.baseUrl = grayskullClientConfiguration.getHost();
-        this.authHeaderProvider = authHeaderProvider;
-        this.grayskullClientConfiguration = grayskullClientConfiguration;
-        this.httpClient = new GrayskullHttpClient(authHeaderProvider, grayskullClientConfiguration);
-        
+        this.httpClient = new GrayskullHttpClient(
+                authHeaderProvider, grayskullClientConfiguration, hostIdentityProvider);
+
         this.objectMapper = new ObjectMapper();
         this.objectMapper.registerModule(new ParameterNamesModule());
-        
-        // Configure metrics based on client configuration
+
+        this.refreshManager = new SecretRefreshManager(
+                httpClient,
+                buildUrl("v1", "secrets", "batch"),
+                objectMapper,
+                grayskullClientConfiguration.getPollIntervalSeconds());
+
         MetricsPublisher.configure(grayskullClientConfiguration.isMetricsEnabled());
     }
-    
+
     /**
      * Retrieves a secret from the Grayskull server.
      * <p>
@@ -87,52 +108,34 @@ public final class GrayskullClientImpl implements GrayskullClient {
         MDC.put(MDCKeys.GRAYSKULL_REQUEST_ID, requestId);
 
         long startTime = System.nanoTime();
-        
+
         int statusCode = 0;
 
         try {
-            if (secretRef == null || secretRef.isEmpty()) {
-                throw new IllegalArgumentException("secretRef cannot be null or empty");
-            }
-
-            // Parse secretRef format: "projectId:secretName"
-            String[] parts = secretRef.split(":", 2);
-            if (parts.length != 2) {
-                throw new IllegalArgumentException(
-                        "Invalid secretRef format. Expected 'projectId:secretName', got: " + secretRef);
-            }
-
+            String[] parts = parseSecretRef(secretRef);
             String projectId = parts[0];
             String secretName = parts[1];
 
-            if (projectId.isEmpty() || secretName.isEmpty()) {
-                throw new IllegalArgumentException(
-                        "projectId and secretName cannot be empty in secretRef: " + secretRef);
-            }
-
-            // Put context in MDC for automatic inclusion in all log statements
             MDC.put(MDCKeys.PROJECT_ID, projectId);
             MDC.put(MDCKeys.SECRET_NAME, secretName);
 
             log.debug("[RequestId:{}] Fetching secret for secretRef: {}", requestId, secretRef);
 
             String url = buildUrl("v1", "projects", projectId, "secrets", secretName, "data");
-            
-            // Fetch the secret with automatic retry logic
+
             HttpResponse httpResponse = httpClient.doGetWithRetry(url);
             statusCode = httpResponse.getStatusCode();
-            
+
             Response<SecretValue> response = objectMapper.readValue(httpResponse.getBody(), SECRET_VALUE_TYPE_REFERENCE);
             SecretValue secretValue = response.getData();
 
             if (secretValue == null) {
                 throw new GrayskullException(500, "No data in response");
             }
-            
+
             return secretValue;
-            
+
         } catch (JsonProcessingException e) {
-            // JSON parsing errors are not retryable - they indicate a permanent problem
             throw new GrayskullException("Failed to parse response: ", e);
         } catch (GrayskullException e) {
             statusCode = e.getStatusCode();
@@ -141,8 +144,7 @@ public final class GrayskullClientImpl implements GrayskullClient {
             long duration = System.nanoTime() - startTime;
             long durationMs = TimeUnit.NANOSECONDS.toMillis(duration);
             MetricsPublisher.getInstance().recordRequest("getSecret." + secretRef, statusCode, durationMs);
-            
-            // Clean up MDC context
+
             MDC.remove(MDCKeys.PROJECT_ID);
             MDC.remove(MDCKeys.SECRET_NAME);
             MDC.remove(MDCKeys.GRAYSKULL_REQUEST_ID);
@@ -152,33 +154,46 @@ public final class GrayskullClientImpl implements GrayskullClient {
     /**
      * Registers a refresh hook for a secret.
      * <p>
-     * Note: This is a placeholder implementation. The hook will be registered but
-     * will not be invoked until server-side long-polling support is implemented.
-     * This allows applications to include hook registration code now, and it will
-     * automatically work when upgrading to a future SDK version with full support.
-     * </p>
+     * This method fetches the current secret value synchronously and invokes the hook
+     * immediately, ensuring the application has the latest value at boot time. The hook
+     * is then registered for ongoing polling — the SDK will check for version changes
+     * at a configurable interval (default 30s) and invoke the hook when updates are detected.
+     * <p>
+     * Multiple hooks may be registered for the same {@code secretRef}; they will all be
+     * invoked in registration order when an update is detected. Each returned
+     * {@link RefreshHandlerRef#unRegister()} removes only that specific registration.
      *
-     * @param secretRef the secret reference to monitor
+     * @param secretRef the secret reference to monitor, in format "projectId:secretName"
      * @param hook the hook to invoke when the secret is refreshed
-     * @return a handle that can be used to check status or unregister the hook
+     * @return a handle that can be used to check status and unregister the hook
      */
     @Override
     public RefreshHandlerRef registerRefreshHook(String secretRef, SecretRefreshHook hook) {
         String requestId = generateRequestId();
         MDC.put(MDCKeys.GRAYSKULL_REQUEST_ID, requestId);
         try {
-
-            if (secretRef == null || secretRef.isEmpty()) {
-                throw new IllegalArgumentException("secretRef cannot be null or empty");
-            }
+            // Validate upfront so we never register a malformed ref into the poller.
+            parseSecretRef(secretRef);
             if (hook == null) {
                 throw new IllegalArgumentException("hook cannot be null");
             }
 
-            log.debug("[RequestId:{}] Registering refresh hook for secretRef:{} (placeholder implementation)", requestId, secretRef);
+            log.info("[RequestId:{}] Registering refresh hook for secretRef: {}", requestId, secretRef);
 
-            // TODO: Implement actual hook invocation when server-side events support is added
-            return NoOpRefreshHandlerRef.INSTANCE;
+            SecretValue currentValue = getSecret(secretRef);
+
+            try {
+                hook.onUpdate(currentValue);
+            } catch (Exception e) {
+                // Initial invocation errors are surfaced to logs only — the
+                // hook stays registered; we cannot unwind whatever side effect
+                // the user's code may have already performed.
+                log.warn("[RequestId:{}] Hook threw during initial invocation for {}", requestId, secretRef, e);
+            }
+
+            long hookId = refreshManager.register(secretRef, hook, currentValue.getDataVersion());
+
+            return new ActiveRefreshHandlerRef(secretRef, hookId, refreshManager);
 
         } finally {
             MDC.remove(MDCKeys.GRAYSKULL_REQUEST_ID);
@@ -187,32 +202,46 @@ public final class GrayskullClientImpl implements GrayskullClient {
 
     /**
      * Closes the client and releases resources.
-     * <p>
-     * This method should be called when the client is no longer needed to properly
-     * clean up HTTP connections and other resources.
-     * </p>
      */
     @Override
     public void close() {
         log.info("Closing Grayskull client");
+        if (refreshManager != null) {
+            refreshManager.shutdown();
+        }
         if (httpClient != null) {
             httpClient.close();
         }
     }
-
 
     private String buildUrl(String... pathSegments) {
         HttpUrl parsedBaseUrl = HttpUrl.parse(baseUrl);
         if (parsedBaseUrl == null) {
             throw new IllegalStateException("Invalid baseUrl: " + baseUrl);
         }
-        
+
         HttpUrl.Builder builder = parsedBaseUrl.newBuilder();
         for (String segment : pathSegments) {
             builder.addPathSegment(segment);
         }
-        
+
         return builder.build().toString();
+    }
+
+    private static String[] parseSecretRef(String secretRef) {
+        if (secretRef == null || secretRef.isEmpty()) {
+            throw new IllegalArgumentException("secretRef cannot be null or empty");
+        }
+        String[] parts = secretRef.split(":", 2);
+        if (parts.length != 2) {
+            throw new IllegalArgumentException(
+                    "Invalid secretRef format. Expected 'projectId:secretName', got: " + secretRef);
+        }
+        if (parts[0].isEmpty() || parts[1].isEmpty()) {
+            throw new IllegalArgumentException(
+                    "projectId and secretName cannot be empty in secretRef: " + secretRef);
+        }
+        return parts;
     }
 
     private String generateRequestId() {

--- a/clients/java/client-impl/src/main/java/com/flipkart/grayskull/GrayskullHttpClient.java
+++ b/clients/java/client-impl/src/main/java/com/flipkart/grayskull/GrayskullHttpClient.java
@@ -7,6 +7,9 @@ import com.flipkart.grayskull.models.response.HttpResponse;
 import com.flipkart.grayskull.models.exceptions.GrayskullException;
 import com.flipkart.grayskull.models.exceptions.RetryableException;
 import com.flipkart.grayskull.metrics.MetricsPublisher;
+import com.flipkart.grayskull.spi.DefaultHostIdentityProvider;
+import com.flipkart.grayskull.spi.HostIdentityProvider;
+import com.flipkart.grayskull.spi.SdkVersion;
 import com.flipkart.grayskull.utils.RetryUtil;
 import okhttp3.*;
 import org.slf4j.Logger;
@@ -17,17 +20,57 @@ import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * HTTP transport for the Grayskull client.
+ * <p>
+ * This class is intentionally kept free of any Kubernetes-specific coupling;
+ * host identity (what Flipkart's deployments surface as the K8s SA token) is
+ * injected via a pluggable {@link HostIdentityProvider} so the OSS artifact
+ * stays environment-agnostic.
+ * <p>
+ * <b>Headers added on every outbound request</b> (today only the two data-plane
+ * endpoints — {@code GET /secrets/{name}/data} and {@code POST /secrets/batch}
+ * — invoke this client, so the headers are scoped to those calls by virtue of
+ * the call surface rather than by an annotation/AOP layer):
+ * <ul>
+ *   <li>{@code Authorization} — from {@link GrayskullAuthHeaderProvider}.</li>
+ *   <li>{@code X-Request-Id} — from MDC, propagated for correlation.</li>
+ *   <li>{@code X-Grayskull-SDK-Version} — resolved once from a Maven-filtered
+ *       resource via {@link SdkVersion}.</li>
+ *   <li>{@code X-Grayskull-Host-Identification} — from the injected
+ *       {@link HostIdentityProvider}; omitted when the provider returns blank.</li>
+ * </ul>
+ */
 class GrayskullHttpClient {
     private static final Logger log = LoggerFactory.getLogger(GrayskullHttpClient.class);
+    private static final MediaType JSON_MEDIA_TYPE = MediaType.get("application/json; charset=utf-8");
+
+    static final String HEADER_AUTHORIZATION = "Authorization";
+    static final String HEADER_REQUEST_ID = "X-Request-Id";
+    static final String HEADER_SDK_VERSION = "X-Grayskull-SDK-Version";
+    static final String HEADER_HOST_IDENTIFICATION = "X-Grayskull-Host-Identification";
 
     private final OkHttpClient httpClient;
     private final GrayskullAuthHeaderProvider authHeaderProvider;
+    private final HostIdentityProvider hostIdentityProvider;
     private final RetryUtil retryUtil;
+    private final String sdkVersion;
 
+    GrayskullHttpClient(GrayskullAuthHeaderProvider authHeaderProvider,
+                        GrayskullClientConfiguration clientConfiguration) {
+        this(authHeaderProvider, clientConfiguration, new DefaultHostIdentityProvider());
+    }
 
-    GrayskullHttpClient(GrayskullAuthHeaderProvider authHeaderProvider, GrayskullClientConfiguration clientConfiguration) {
+    GrayskullHttpClient(GrayskullAuthHeaderProvider authHeaderProvider,
+                        GrayskullClientConfiguration clientConfiguration,
+                        HostIdentityProvider hostIdentityProvider) {
+        if (hostIdentityProvider == null) {
+            throw new IllegalArgumentException("hostIdentityProvider cannot be null");
+        }
         this.authHeaderProvider = authHeaderProvider;
-        
+        this.hostIdentityProvider = hostIdentityProvider;
+        this.sdkVersion = SdkVersion.get();
+
         this.httpClient = new OkHttpClient.Builder()
                 .connectTimeout(clientConfiguration.getConnectionTimeout(), TimeUnit.MILLISECONDS)
                 .readTimeout(clientConfiguration.getReadTimeout(), TimeUnit.MILLISECONDS)
@@ -36,42 +79,36 @@ class GrayskullHttpClient {
                         5,
                         TimeUnit.MINUTES))
                 .build();
-        
-        // Initialize retry utility
+
         this.retryUtil = new RetryUtil(clientConfiguration.getMaxRetries(), clientConfiguration.getMinRetryDelay());
     }
 
     HttpResponse doGetWithRetry(String url) {
         final int[] attemptCount = {0};
         boolean finalAttemptSuccess = false;
-        
+
         try {
             HttpResponse result = retryUtil.retry(() -> {
                 attemptCount[0]++;
                 return doGet(url);
             });
-            
+
             finalAttemptSuccess = true;
             return result;
-            
+
         } catch (IllegalStateException | IllegalArgumentException e) {
-            // Configuration or usage errors - rethrow as-is
             throw e;
-        
         } catch (GrayskullException e) {
-            // GrayskullException already has proper context (retry exhaustion, etc.) - rethrow as-is
             throw e;
-            
         } catch (Exception e) {
             throw new GrayskullException(500, "Unexpected error during HTTP request", e);
-
         } finally {
             if (attemptCount[0] > 1) {
                 MetricsPublisher.getInstance().recordRetry(url, attemptCount[0], finalAttemptSuccess);
             }
         }
     }
-    
+
     HttpResponse doGet(String url) throws RetryableException {
         Request request = buildRequest(url)
                 .get()
@@ -83,9 +120,53 @@ class GrayskullHttpClient {
 
         String body = httpResponse.getBody();
         int bodyLength = body != null ? body.length() : 0;
-        log.debug("[RequestId:{}] Received response from {} with status: {}, protocol: {}, contentType: {}, bodyLength: {} bytes", 
+        log.debug("[RequestId:{}] Received response from {} with status: {}, protocol: {}, contentType: {}, bodyLength: {} bytes",
                 requestId, url, httpResponse.getStatusCode(), httpResponse.getProtocol(), httpResponse.getContentType(), bodyLength);
-        
+
+        return httpResponse;
+    }
+
+    HttpResponse doPostWithRetry(String url, String jsonBody) {
+        final int[] attemptCount = {0};
+        boolean finalAttemptSuccess = false;
+
+        try {
+            HttpResponse result = retryUtil.retry(() -> {
+                attemptCount[0]++;
+                return doPost(url, jsonBody);
+            });
+
+            finalAttemptSuccess = true;
+            return result;
+
+        } catch (IllegalStateException | IllegalArgumentException e) {
+            throw e;
+        } catch (GrayskullException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new GrayskullException(500, "Unexpected error during HTTP request", e);
+        } finally {
+            if (attemptCount[0] > 1) {
+                MetricsPublisher.getInstance().recordRetry(url, attemptCount[0], finalAttemptSuccess);
+            }
+        }
+    }
+
+    HttpResponse doPost(String url, String jsonBody) throws RetryableException {
+        RequestBody body = RequestBody.create(jsonBody, JSON_MEDIA_TYPE);
+        Request request = buildRequest(url)
+                .post(body)
+                .build();
+
+        String requestId = MDC.get(MDCKeys.GRAYSKULL_REQUEST_ID);
+        log.debug("[RequestId:{}] Executing POST request to: {}", requestId, url);
+        HttpResponse httpResponse = executeRequest(request);
+
+        String responseBody = httpResponse.getBody();
+        int bodyLength = responseBody != null ? responseBody.length() : 0;
+        log.debug("[RequestId:{}] Received POST response from {} with status: {}, bodyLength: {} bytes",
+                requestId, url, httpResponse.getStatusCode(), bodyLength);
+
         return httpResponse;
     }
 
@@ -96,11 +177,23 @@ class GrayskullHttpClient {
         if (authHeader == null || authHeader.trim().isEmpty()) {
             throw new IllegalStateException("Auth header cannot be null or empty");
         }
-        requestBuilder.addHeader("Authorization", authHeader);
+        requestBuilder.addHeader(HEADER_AUTHORIZATION, authHeader);
 
         String requestId = MDC.get(MDCKeys.GRAYSKULL_REQUEST_ID);
         if (requestId != null && !requestId.isEmpty()) {
-            requestBuilder.addHeader("X-Request-Id", requestId);
+            requestBuilder.addHeader(HEADER_REQUEST_ID, requestId);
+        }
+
+        requestBuilder.addHeader(HEADER_SDK_VERSION, sdkVersion);
+
+        String hostId = hostIdentityProvider.getHostIdentification();
+        // Defensive sanitisation: strip CR/LF to prevent HTTP header injection
+        // even though the SPI contract forbids them. Empty => omit the header
+        // (per contract) so the server can distinguish "no identity" from a
+        // literal empty string.
+        if (hostId != null && !hostId.isEmpty()) {
+            String sanitised = hostId.replace('\r', ' ').replace('\n', ' ');
+            requestBuilder.addHeader(HEADER_HOST_IDENTIFICATION, sanitised);
         }
 
         return requestBuilder;
@@ -109,11 +202,10 @@ class GrayskullHttpClient {
     private HttpResponse executeRequest(Request request) throws RetryableException {
         try (okhttp3.Response response = httpClient.newCall(request).execute()) {
             int statusCode = response.code();
-            
+
             if (!response.isSuccessful()) {
                 String errorBody = response.body() != null ? response.body().string() : "";
-                
-                // Determine if the error is retryable
+
                 if (isRetryableStatusCode(statusCode)) {
                     throw new RetryableException(statusCode, "Request failed: " + errorBody);
                 } else {
@@ -127,15 +219,13 @@ class GrayskullHttpClient {
             return new HttpResponse(statusCode, responseBody, contentType, protocol);
 
         } catch (SocketTimeoutException e) {
-            // Timeout errors (connection or read timeout)
             throw new RetryableException(500, "Timeout while communicating with Grayskull server", e);
-            
+
         } catch (IOException e) {
-            // Network/IO errors are generally transient and worth retrying
             throw new RetryableException(500, "Error communicating with Grayskull server", e);
         }
     }
-    
+
     private boolean isRetryableStatusCode(int statusCode) {
         return statusCode == 429 || (statusCode >= 500 && statusCode < 600);
     }

--- a/clients/java/client-impl/src/main/java/com/flipkart/grayskull/SecretRefreshManager.java
+++ b/clients/java/client-impl/src/main/java/com/flipkart/grayskull/SecretRefreshManager.java
@@ -1,0 +1,295 @@
+package com.flipkart.grayskull;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flipkart.grayskull.hooks.SecretRefreshHook;
+import com.flipkart.grayskull.metrics.MetricsPublisher;
+import com.flipkart.grayskull.models.SecretValue;
+import com.flipkart.grayskull.models.request.BatchGetSecretsRequest;
+import com.flipkart.grayskull.models.request.SecretVersionEntry;
+import com.flipkart.grayskull.models.response.BatchGetSecretsResponse;
+import com.flipkart.grayskull.models.response.BatchSecretItem;
+import com.flipkart.grayskull.models.response.HttpResponse;
+import com.flipkart.grayskull.models.response.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Manages registered secret refresh hooks and polls the server for changes.
+ * <p>
+ * <b>Invariants / design:</b>
+ * <ul>
+ *   <li>Any number of hooks may be registered for the same {@code secretRef};
+ *       they are invoked in registration order on update.</li>
+ *   <li>Each hook carries its own {@code lastKnownVersion} so late-registered
+ *       hooks (which start at the current version) don't cause re-invocation
+ *       of hooks that are already caught up.</li>
+ *   <li>The polling thread is started lazily on first {@link #register} and
+ *       left running until {@link #shutdown()}. This is the in-memory
+ *       {@code registeredHooks} flag in practice: "scheduler != null" ≡ "at
+ *       least one hook has ever been registered".</li>
+ *   <li>Poll batches are capped at {@value #MAX_BATCH_SIZE}, matching the
+ *       server's batch-get limit.</li>
+ *   <li>A single transient poll failure must not break future polls; errors
+ *       and hook exceptions are caught and logged, not propagated.</li>
+ * </ul>
+ */
+class SecretRefreshManager {
+
+    private static final Logger log = LoggerFactory.getLogger(SecretRefreshManager.class);
+    static final int MAX_BATCH_SIZE = 50;
+    private static final TypeReference<Response<BatchGetSecretsResponse>> BATCH_RESPONSE_TYPE =
+            new TypeReference<Response<BatchGetSecretsResponse>>() {};
+
+    private final ConcurrentHashMap<String, CopyOnWriteArrayList<HookRegistration>> hooksBySecret =
+            new ConcurrentHashMap<>();
+    private final AtomicLong hookIdSeq = new AtomicLong(0);
+
+    private final GrayskullHttpClient httpClient;
+    private final String batchUrl;
+    private final ObjectMapper objectMapper;
+    private final int pollIntervalSeconds;
+
+    private volatile ScheduledExecutorService scheduler;
+    private final Object schedulerLock = new Object();
+
+    SecretRefreshManager(GrayskullHttpClient httpClient, String batchUrl,
+                         ObjectMapper objectMapper, int pollIntervalSeconds) {
+        this.httpClient = httpClient;
+        this.batchUrl = batchUrl;
+        this.objectMapper = objectMapper;
+        this.pollIntervalSeconds = pollIntervalSeconds;
+    }
+
+    /**
+     * Registers a hook and returns a stable id that can be passed to
+     * {@link #unregister(String, long)} to remove precisely this registration
+     * (without affecting other hooks for the same secret).
+     */
+    long register(String secretRef, SecretRefreshHook hook, int lastKnownVersion) {
+        long id = hookIdSeq.incrementAndGet();
+        HookRegistration registration = new HookRegistration(id, hook, lastKnownVersion);
+        hooksBySecret
+                .computeIfAbsent(secretRef, k -> new CopyOnWriteArrayList<>())
+                .add(registration);
+        ensureSchedulerStarted();
+        return id;
+    }
+
+    /**
+     * Removes the hook with the given id from the given secret's list, if present.
+     * <p>
+     * Idempotent: calling with an unknown id, or after the hook has already been
+     * removed, is a no-op. If the secret's hook list becomes empty, the entry
+     * is pruned from the map so subsequent polls no longer include it.
+     *
+     * @return {@code true} iff a registration was actually removed.
+     */
+    boolean unregister(String secretRef, long hookId) {
+        CopyOnWriteArrayList<HookRegistration> list = hooksBySecret.get(secretRef);
+        if (list == null) {
+            return false;
+        }
+        boolean removed = false;
+        Iterator<HookRegistration> it = list.iterator();
+        while (it.hasNext()) {
+            HookRegistration reg = it.next();
+            if (reg.id == hookId) {
+                removed = list.remove(reg);
+                break;
+            }
+        }
+        if (list.isEmpty()) {
+            // Compute-with-remove race guard: only remove if still empty.
+            hooksBySecret.computeIfPresent(secretRef, (k, v) -> v.isEmpty() ? null : v);
+        }
+        return removed;
+    }
+
+    void poll() {
+        try {
+            List<Map.Entry<String, CopyOnWriteArrayList<HookRegistration>>> entries =
+                    new ArrayList<>(hooksBySecret.entrySet());
+            if (entries.isEmpty()) {
+                return;
+            }
+            for (int i = 0; i < entries.size(); i += MAX_BATCH_SIZE) {
+                List<Map.Entry<String, CopyOnWriteArrayList<HookRegistration>>> batch =
+                        entries.subList(i, Math.min(i + MAX_BATCH_SIZE, entries.size()));
+                pollBatch(batch);
+            }
+        } catch (Exception e) {
+            // Top-level safety net: poll() runs on a ScheduledExecutor; an
+            // uncaught exception would silently cancel future polls.
+            log.warn("Error during secret refresh poll", e);
+        }
+    }
+
+    void shutdown() {
+        synchronized (schedulerLock) {
+            if (scheduler != null) {
+                scheduler.shutdownNow();
+                log.info("Stopped secret refresh poller");
+            }
+        }
+    }
+
+    int hookCount() {
+        int total = 0;
+        for (CopyOnWriteArrayList<HookRegistration> list : hooksBySecret.values()) {
+            total += list.size();
+        }
+        return total;
+    }
+
+    int secretCount() {
+        return hooksBySecret.size();
+    }
+
+    private void ensureSchedulerStarted() {
+        if (scheduler == null) {
+            synchronized (schedulerLock) {
+                if (scheduler == null) {
+                    scheduler = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
+                        @Override
+                        public Thread newThread(Runnable r) {
+                            Thread t = new Thread(r, "grayskull-poll");
+                            t.setDaemon(true);
+                            return t;
+                        }
+                    });
+                    long jitterMs = ThreadLocalRandom.current().nextLong(pollIntervalSeconds * 1000L);
+                    scheduler.scheduleWithFixedDelay(
+                            this::poll,
+                            jitterMs,
+                            pollIntervalSeconds * 1000L,
+                            TimeUnit.MILLISECONDS);
+                    log.info("Started secret refresh poller (interval={}s, initialDelay={}ms)",
+                            pollIntervalSeconds, jitterMs);
+                }
+            }
+        }
+    }
+
+    private void pollBatch(List<Map.Entry<String, CopyOnWriteArrayList<HookRegistration>>> batch) {
+        long startTime = System.nanoTime();
+        int statusCode = 0;
+
+        try {
+            List<SecretVersionEntry> secretEntries = new ArrayList<>();
+            for (Map.Entry<String, CopyOnWriteArrayList<HookRegistration>> entry : batch) {
+                String[] parts = entry.getKey().split(":", 2);
+                if (parts.length != 2) {
+                    // A malformed secretRef should never reach here (the client
+                    // validates before registering), but if it does we skip
+                    // the entry rather than 400 the whole batch.
+                    log.warn("Skipping malformed secretRef in poll: {}", entry.getKey());
+                    continue;
+                }
+                int minVersion = minLastKnownVersion(entry.getValue());
+                secretEntries.add(new SecretVersionEntry(parts[0], parts[1], minVersion));
+            }
+            if (secretEntries.isEmpty()) {
+                return;
+            }
+
+            BatchGetSecretsRequest request = new BatchGetSecretsRequest(secretEntries);
+            String json = objectMapper.writeValueAsString(request);
+
+            HttpResponse httpResponse = httpClient.doPostWithRetry(batchUrl, json);
+            statusCode = httpResponse.getStatusCode();
+
+            Response<BatchGetSecretsResponse> response = objectMapper.readValue(
+                    httpResponse.getBody(), BATCH_RESPONSE_TYPE);
+            BatchGetSecretsResponse batchResponse = response.getData();
+
+            if (batchResponse == null || batchResponse.getUpdatedSecrets() == null) {
+                return;
+            }
+
+            for (BatchSecretItem updated : batchResponse.getUpdatedSecrets()) {
+                String secretRef = updated.getProjectId() + ":" + updated.getSecretName();
+                CopyOnWriteArrayList<HookRegistration> registrations = hooksBySecret.get(secretRef);
+                if (registrations == null) {
+                    continue;
+                }
+                // SecretValue is a public, immutable DTO in client-api; construct
+                // it from the flat batch item so the SecretRefreshHook contract
+                // (onUpdate(SecretValue)) stays stable.
+                SecretValue secretValue = new SecretValue(
+                        updated.getDataVersion(),
+                        updated.getPublicPart(),
+                        updated.getPrivatePart());
+                invokeHooksInOrder(secretRef, registrations, updated.getDataVersion(), secretValue);
+            }
+
+        } catch (Exception e) {
+            log.warn("Failed to poll batch of {} secrets", batch.size(), e);
+        } finally {
+            long durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
+            MetricsPublisher.getInstance().recordRequest("batchGetSecrets", statusCode, durationMs);
+        }
+    }
+
+    private void invokeHooksInOrder(String secretRef,
+                                    CopyOnWriteArrayList<HookRegistration> registrations,
+                                    int newVersion,
+                                    SecretValue value) {
+        for (HookRegistration reg : registrations) {
+            if (reg.lastKnownVersion >= newVersion) {
+                // This hook is already caught up (can happen when a late
+                // register() picked up a version newer than other hooks').
+                continue;
+            }
+            try {
+                reg.hook.onUpdate(value);
+                reg.lastKnownVersion = newVersion;
+                log.debug("Hook {} invoked for {} (new version={})",
+                        reg.id, secretRef, newVersion);
+            } catch (Exception e) {
+                // Per-hook failure isolation: we do NOT advance lastKnownVersion
+                // on failure so the hook will be retried on the next poll. We
+                // continue to the next hook in registration order.
+                log.warn("Hook {} threw for secret {}", reg.id, secretRef, e);
+            }
+        }
+    }
+
+    private static int minLastKnownVersion(CopyOnWriteArrayList<HookRegistration> registrations) {
+        int min = Integer.MAX_VALUE;
+        for (HookRegistration reg : registrations) {
+            if (reg.lastKnownVersion < min) {
+                min = reg.lastKnownVersion;
+            }
+        }
+        // If the list somehow became empty between iteration and read (races
+        // with unregister), treat it as "nothing to poll" by returning MAX,
+        // which the server will accept and return no updates for.
+        return min == Integer.MAX_VALUE ? 0 : min;
+    }
+
+    static final class HookRegistration {
+        final long id;
+        final SecretRefreshHook hook;
+        volatile int lastKnownVersion;
+
+        HookRegistration(long id, SecretRefreshHook hook, int lastKnownVersion) {
+            this.id = id;
+            this.hook = hook;
+            this.lastKnownVersion = lastKnownVersion;
+        }
+    }
+}

--- a/clients/java/client-impl/src/main/java/com/flipkart/grayskull/hooks/ActiveRefreshHandlerRef.java
+++ b/clients/java/client-impl/src/main/java/com/flipkart/grayskull/hooks/ActiveRefreshHandlerRef.java
@@ -1,0 +1,64 @@
+package com.flipkart.grayskull.hooks;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.flipkart.grayskull.SecretRefreshManager;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Handle returned when a refresh hook is successfully registered.
+ * <p>
+ * Holds a back-reference to the owning {@link SecretRefreshManager} plus a
+ * stable {@code hookId} so {@link #unRegister()} can remove precisely this
+ * registration without affecting any sibling hooks registered for the same
+ * secret.
+ * <p>
+ * {@link #unRegister()} is idempotent and thread-safe: repeated calls and
+ * concurrent calls will remove at most once; subsequent {@link #isActive()}
+ * checks return {@code false}.
+ */
+@Slf4j
+public final class ActiveRefreshHandlerRef implements RefreshHandlerRef {
+
+    private final String secretRef;
+    private final long hookId;
+    private final SecretRefreshManager manager;
+    private final AtomicBoolean active;
+
+    public ActiveRefreshHandlerRef(String secretRef, long hookId, SecretRefreshManager manager) {
+        if (secretRef == null || secretRef.isEmpty()) {
+            throw new IllegalArgumentException("secretRef cannot be null or empty");
+        }
+        if (manager == null) {
+            throw new IllegalArgumentException("manager cannot be null");
+        }
+        this.secretRef = secretRef;
+        this.hookId = hookId;
+        this.manager = manager;
+        this.active = new AtomicBoolean(true);
+    }
+
+    @Override
+    public String getSecretRef() {
+        return secretRef;
+    }
+
+    @Override
+    public boolean isActive() {
+        return active.get();
+    }
+
+    @Override
+    public void unRegister() {
+        // compareAndSet ensures exactly-once removal under concurrent unRegister
+        // calls; the manager itself is idempotent but we avoid the log spam.
+        if (active.compareAndSet(true, false)) {
+            boolean removed = manager.unregister(secretRef, hookId);
+            if (log.isDebugEnabled()) {
+                log.debug("unRegister called for {} (hookId={}, removedFromManager={})",
+                        secretRef, hookId, removed);
+            }
+        }
+    }
+}

--- a/clients/java/client-impl/src/main/java/com/flipkart/grayskull/models/GrayskullClientConfiguration.java
+++ b/clients/java/client-impl/src/main/java/com/flipkart/grayskull/models/GrayskullClientConfiguration.java
@@ -87,6 +87,19 @@ public final class GrayskullClientConfiguration {
     private int minRetryDelay = 100;
 
     /**
+     * The interval in seconds between secret refresh polls.
+     * <p>
+     * When refresh hooks are registered, the SDK will poll the server for version changes
+     * at this interval. A shorter interval means faster detection of changes but more
+     * server load.
+     * </p>
+     * <p>
+     * Default: 30 seconds. Minimum: 10 seconds.
+     * </p>
+     */
+    private int pollIntervalSeconds = 30;
+
+    /**
      * Whether to enable metrics collection.
      * <p>
      * When enabled, the client will expose metrics about API calls (success/failure counts,
@@ -179,5 +192,18 @@ public final class GrayskullClientConfiguration {
             throw new IllegalArgumentException("Min retry delay must be at least 50ms, got: " + minRetryDelay);
         }
         this.minRetryDelay = minRetryDelay;
+    }
+
+    /**
+     * Sets the interval between secret refresh polls in seconds.
+     *
+     * @param pollIntervalSeconds the poll interval in seconds (must be at least 10)
+     * @throws IllegalArgumentException if pollIntervalSeconds is less than 10
+     */
+    public void setPollIntervalSeconds(int pollIntervalSeconds) {
+        if (pollIntervalSeconds < 10) {
+            throw new IllegalArgumentException("Poll interval must be at least 10 seconds, got: " + pollIntervalSeconds);
+        }
+        this.pollIntervalSeconds = pollIntervalSeconds;
     }
 }

--- a/clients/java/client-impl/src/main/java/com/flipkart/grayskull/models/request/BatchGetSecretsRequest.java
+++ b/clients/java/client-impl/src/main/java/com/flipkart/grayskull/models/request/BatchGetSecretsRequest.java
@@ -1,0 +1,13 @@
+package com.flipkart.grayskull.models.request;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(onConstructor = @__(@JsonCreator))
+public final class BatchGetSecretsRequest {
+    private final List<SecretVersionEntry> secrets;
+}

--- a/clients/java/client-impl/src/main/java/com/flipkart/grayskull/models/request/SecretVersionEntry.java
+++ b/clients/java/client-impl/src/main/java/com/flipkart/grayskull/models/request/SecretVersionEntry.java
@@ -1,0 +1,13 @@
+package com.flipkart.grayskull.models.request;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(onConstructor = @__(@JsonCreator))
+public final class SecretVersionEntry {
+    private final String projectId;
+    private final String secretName;
+    private final int lastKnownVersion;
+}

--- a/clients/java/client-impl/src/main/java/com/flipkart/grayskull/models/response/BatchGetSecretsResponse.java
+++ b/clients/java/client-impl/src/main/java/com/flipkart/grayskull/models/response/BatchGetSecretsResponse.java
@@ -1,0 +1,16 @@
+package com.flipkart.grayskull.models.response;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(onConstructor = @__(@JsonCreator))
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class BatchGetSecretsResponse {
+    private final int updatedCount;
+    private final List<BatchSecretItem> updatedSecrets;
+}

--- a/clients/java/client-impl/src/main/java/com/flipkart/grayskull/models/response/BatchSecretItem.java
+++ b/clients/java/client-impl/src/main/java/com/flipkart/grayskull/models/response/BatchSecretItem.java
@@ -1,0 +1,27 @@
+package com.flipkart.grayskull.models.response;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * A single item in a {@link BatchGetSecretsResponse}.
+ * <p>
+ * Carries the identity of the secret ({@code projectId}, {@code secretName})
+ * along with its current decrypted data fields, flat (un-nested).
+ * <p>
+ * Only the fields needed by the client SDK are declared here; additional
+ * server-side fields (e.g. timestamps, audit metadata) are ignored via
+ * {@link JsonIgnoreProperties}.
+ */
+@Getter
+@AllArgsConstructor(onConstructor = @__(@JsonCreator))
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class BatchSecretItem {
+    private final String projectId;
+    private final String secretName;
+    private final int dataVersion;
+    private final String publicPart;
+    private final String privatePart;
+}

--- a/clients/java/client-impl/src/main/java/com/flipkart/grayskull/spi/DefaultHostIdentityProvider.java
+++ b/clients/java/client-impl/src/main/java/com/flipkart/grayskull/spi/DefaultHostIdentityProvider.java
@@ -1,0 +1,68 @@
+package com.flipkart.grayskull.spi;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Default, OSS-friendly implementation of {@link HostIdentityProvider}.
+ * <p>
+ * Resolves the local hostname once at construction time via
+ * {@link InetAddress#getLocalHost()} and caches it. If the hostname cannot be
+ * resolved (e.g. misconfigured DNS on a minimal container) it falls back to
+ * {@code "unknown-host"} so we never return {@code null} and never let a header
+ * value leak an exception trail.
+ * <p>
+ * This class intentionally carries no Kubernetes dependency; production
+ * deployments that need a verifiable identity should supply their own
+ * {@link HostIdentityProvider} (for instance, one that reads a projected
+ * service-account token) at client construction time.
+ */
+public final class DefaultHostIdentityProvider implements HostIdentityProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(DefaultHostIdentityProvider.class);
+    private static final String UNKNOWN = "unknown-host";
+
+    private final String hostIdentification;
+
+    public DefaultHostIdentityProvider() {
+        this(DefaultHostIdentityProvider::systemHostname);
+    }
+
+    // Package-private seam for tests to force the fallback branch without
+    // needing to mock InetAddress at the bytecode level.
+    DefaultHostIdentityProvider(HostnameResolver resolver) {
+        this.hostIdentification = resolveOrFallback(resolver);
+    }
+
+    @Override
+    public String getHostIdentification() {
+        return hostIdentification;
+    }
+
+    private static String resolveOrFallback(HostnameResolver resolver) {
+        try {
+            String name = resolver.resolve();
+            if (name == null || name.trim().isEmpty()) {
+                return UNKNOWN;
+            }
+            return name.trim();
+        } catch (UnknownHostException e) {
+            // Explicitly benign: we fall back to a sentinel so the caller can
+            // still send requests; the server will just see no meaningful id.
+            log.debug("Unable to resolve local hostname; using fallback identity", e);
+            return UNKNOWN;
+        }
+    }
+
+    private static String systemHostname() throws UnknownHostException {
+        return InetAddress.getLocalHost().getHostName();
+    }
+
+    @FunctionalInterface
+    interface HostnameResolver {
+        String resolve() throws UnknownHostException;
+    }
+}

--- a/clients/java/client-impl/src/main/java/com/flipkart/grayskull/spi/SdkVersion.java
+++ b/clients/java/client-impl/src/main/java/com/flipkart/grayskull/spi/SdkVersion.java
@@ -1,0 +1,82 @@
+package com.flipkart.grayskull.spi;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Resolves the Grayskull Java client SDK version at class-load time from a
+ * Maven-filtered resource on the classpath ({@code META-INF/grayskull-client.properties}).
+ * <p>
+ * The returned value is used for the {@code X-Grayskull-SDK-Version} header on
+ * data-plane calls. If the resource is missing or unreadable (unexpected in a
+ * normal build, but possible in pathological shaded/repackaged environments),
+ * we fall back to {@code "java/unknown"} and log at debug — never {@code null},
+ * never throw, and never block request flow.
+ */
+public final class SdkVersion {
+
+    private static final Logger log = LoggerFactory.getLogger(SdkVersion.class);
+    static final String RESOURCE_PATH = "META-INF/grayskull-client.properties";
+    static final String PREFIX = "java/";
+    static final String UNKNOWN = PREFIX + "unknown";
+
+    private static final String VERSION = loadFromClassLoader(SdkVersion.class.getClassLoader());
+
+    private SdkVersion() {
+        // Utility class; not instantiable.
+    }
+
+    /**
+     * Returns a string of the form {@code "java/<version>"} (for example
+     * {@code "java/0.1.2"}); {@code "java/unknown"} on bootstrap failure.
+     */
+    public static String get() {
+        return VERSION;
+    }
+
+    // Package-private for testing every branch (null classloader, missing
+    // resource, IO failure, blank/placeholder value).
+    static String loadFromClassLoader(ClassLoader cl) {
+        if (cl == null) {
+            return UNKNOWN;
+        }
+        try (InputStream in = cl.getResourceAsStream(RESOURCE_PATH)) {
+            return parseVersion(in);
+        } catch (IOException e) {
+            log.debug("Failed to load SDK version resource; falling back to '{}'", UNKNOWN, e);
+            return UNKNOWN;
+        }
+    }
+
+    // Package-private for direct exercise of the parse branches.
+    static String parseVersion(InputStream in) throws IOException {
+        if (in == null) {
+            log.debug("Classpath resource '{}' not found; falling back to '{}'",
+                    RESOURCE_PATH, UNKNOWN);
+            return UNKNOWN;
+        }
+        Properties props = new Properties();
+        props.load(in);
+        String raw = props.getProperty("version");
+        if (raw == null || raw.trim().isEmpty() || raw.contains("${")) {
+            // A literal "${project.version}" means Maven resource filtering
+            // did not run (e.g. running straight from IDE before a build);
+            // treat it as unknown rather than echo the placeholder.
+            log.debug("Resolved SDK version is empty or unfiltered ('{}'); falling back", raw);
+            return UNKNOWN;
+        }
+        return PREFIX + raw.trim();
+    }
+
+    // Package-private helper for tests that want a synthetic properties stream
+    // without touching the real classpath.
+    static InputStream propertiesStream(String content) {
+        return new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/clients/java/client-impl/src/main/resources/META-INF/grayskull-client.properties
+++ b/clients/java/client-impl/src/main/resources/META-INF/grayskull-client.properties
@@ -1,0 +1,1 @@
+version=${project.version}

--- a/clients/java/client-impl/src/test/java/com/flipkart/grayskull/GrayskullClientImplTest.java
+++ b/clients/java/client-impl/src/test/java/com/flipkart/grayskull/GrayskullClientImplTest.java
@@ -264,14 +264,17 @@ class GrayskullClientImplTest {
     }
 
     @Test
-    void testRegisterRefreshHook_success() {
+    void testRegisterRefreshHook_success() throws Exception {
         // Given
         String secretRef = "secengg-stage:secret-1";
         AtomicInteger callCount = new AtomicInteger(0);
-        
+        SecretValue expectedSecret = new SecretValue(5, "pub", "priv");
+        HttpResponse httpResponse = createHttpResponse(expectedSecret);
+
+        when(mockHttpClient.doGetWithRetry(anyString())).thenReturn(httpResponse);
+
         SecretRefreshHook hook = (secretVal) -> {
             callCount.incrementAndGet();
-            System.out.println("Secret refreshed: " + secretVal);
         };
 
         // When
@@ -279,25 +282,99 @@ class GrayskullClientImplTest {
 
         // Then
         assertNotNull(handle);
-        // No-op implementation returns empty string and is always inactive
-        assertEquals("", handle.getSecretRef());
-        assertFalse(handle.isActive());
-        
-        // Verify hook was never called (placeholder implementation)
-        assertEquals(0, callCount.get());
+        assertEquals("secengg-stage:secret-1", handle.getSecretRef());
+        assertTrue(handle.isActive());
+        assertEquals(1, callCount.get());
     }
 
     @Test
-    void testRegisterRefreshHook_canUnregister() {
+    void testRegisterRefreshHook_hookExceptionDoesNotPropagate() throws Exception {
         // Given
         String secretRef = "secengg-stage:secret-1";
-        SecretRefreshHook hook = (secretVal) -> System.out.println("test");
+        SecretValue expectedSecret = new SecretValue(5, "pub", "priv");
+        HttpResponse httpResponse = createHttpResponse(expectedSecret);
+
+        when(mockHttpClient.doGetWithRetry(anyString())).thenReturn(httpResponse);
+
+        SecretRefreshHook failingHook = (secretVal) -> {
+            throw new RuntimeException("hook error");
+        };
+
+        // When - should not throw even though hook fails
+        RefreshHandlerRef handle = client.registerRefreshHook(secretRef, failingHook);
+
+        // Then
+        assertNotNull(handle);
+        assertTrue(handle.isActive());
+    }
+
+    @Test
+    void testRegisterRefreshHook_canUnregister() throws Exception {
+        // Given
+        String secretRef = "secengg-stage:secret-1";
+        SecretValue expectedSecret = new SecretValue(5, "pub", "priv");
+        HttpResponse httpResponse = createHttpResponse(expectedSecret);
+
+        when(mockHttpClient.doGetWithRetry(anyString())).thenReturn(httpResponse);
+
+        SecretRefreshHook hook = (secretVal) -> {};
 
         // When
         RefreshHandlerRef handle = client.registerRefreshHook(secretRef, hook);
-        
-        // unRegister() is a no-op but shouldn't throw
+        assertTrue(handle.isActive());
+
+        // Then - unRegister() deactivates the handle and removes the registration
         handle.unRegister();
+        assertFalse(handle.isActive());
+
+        // Idempotent: second call is a no-op, state remains inactive
+        handle.unRegister();
+        assertFalse(handle.isActive());
+    }
+
+    @Test
+    void testRegisterRefreshHook_multipleHooks_perSecret_areAllInvokedInOrder() throws Exception {
+        // Given - two hooks on the same secret; initial getSecret returns v5 for both
+        String secretRef = "proj:secret";
+        SecretValue initial = new SecretValue(5, "pub", "priv");
+        when(mockHttpClient.doGetWithRetry(anyString())).thenReturn(createHttpResponse(initial));
+
+        java.util.List<String> callOrder = new java.util.concurrent.CopyOnWriteArrayList<>();
+        SecretRefreshHook hookA = (v) -> callOrder.add("A");
+        SecretRefreshHook hookB = (v) -> callOrder.add("B");
+
+        // When
+        RefreshHandlerRef refA = client.registerRefreshHook(secretRef, hookA);
+        RefreshHandlerRef refB = client.registerRefreshHook(secretRef, hookB);
+
+        // Then - both hooks were invoked once on registration in order A, B
+        assertEquals(java.util.Arrays.asList("A", "B"), callOrder);
+        assertTrue(refA.isActive());
+        assertTrue(refB.isActive());
+
+        // And unregistering refA leaves refB active
+        refA.unRegister();
+        assertFalse(refA.isActive());
+        assertTrue(refB.isActive());
+    }
+
+    @Test
+    void testConstructor_nullHostIdentityProvider() {
+        GrayskullClientConfiguration config = new GrayskullClientConfiguration();
+        config.setHost("https://test.grayskull.com");
+        assertThrows(IllegalArgumentException.class,
+                () -> new GrayskullClientImpl(mockAuthProvider, config, null),
+                "hostIdentityProvider cannot be null");
+    }
+
+    @Test
+    void testConstructor_customHostIdentityProvider_isAccepted() {
+        GrayskullClientConfiguration config = new GrayskullClientConfiguration();
+        config.setHost("https://test.grayskull.com");
+        GrayskullClientImpl c = new GrayskullClientImpl(
+                mockAuthProvider, config, () -> "my-host");
+        assertNotNull(c);
+        c.close();
     }
 
     @Test
@@ -329,11 +406,15 @@ class GrayskullClientImplTest {
 
     @Test
     void testClose_handlesNullHttpClient() throws Exception {
-        // Given - create client with null http client
+        // Given - create client with null http client and null refresh manager
         GrayskullClientImpl clientWithNullHttp = new GrayskullClientImpl(mockAuthProvider, grayskullClientConfiguration);
         Field httpClientField = GrayskullClientImpl.class.getDeclaredField("httpClient");
         httpClientField.setAccessible(true);
         httpClientField.set(clientWithNullHttp, null);
+
+        Field refreshField = GrayskullClientImpl.class.getDeclaredField("refreshManager");
+        refreshField.setAccessible(true);
+        refreshField.set(clientWithNullHttp, null);
 
         // When/Then - should not throw exception
         clientWithNullHttp.close();

--- a/clients/java/client-impl/src/test/java/com/flipkart/grayskull/GrayskullHttpClientTest.java
+++ b/clients/java/client-impl/src/test/java/com/flipkart/grayskull/GrayskullHttpClientTest.java
@@ -20,7 +20,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
@@ -304,6 +309,190 @@ class GrayskullHttpClientTest {
 
         assertEquals(401, exception.getStatusCode());
         assertEquals(1, mockWebServer.getRequestCount());
+    }
+
+    @Test
+    void testDoPostWithRetry_success() throws InterruptedException {
+        // Given
+        httpClient = new GrayskullHttpClient(mockAuthProvider, config);
+        Response<SecretValue> response = new Response<>(new SecretValue(1, "pub", "priv"), "Success");
+        String jsonResponse = toJson(response);
+
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody(jsonResponse)
+                .addHeader("Content-Type", "application/json"));
+
+        // When
+        HttpResponse result = httpClient.doPostWithRetry(
+                mockWebServer.url("/v1/secrets/batch").toString(),
+                "{\"secrets\":[]}");
+
+        // Then
+        assertNotNull(result);
+        assertEquals(200, result.getStatusCode());
+
+        RecordedRequest request = mockWebServer.takeRequest(1, TimeUnit.SECONDS);
+        assertNotNull(request);
+        assertEquals("POST", request.getMethod());
+        assertEquals("application/json; charset=utf-8", request.getHeader("Content-Type"));
+    }
+
+    @Test
+    void testDoPostWithRetry_includesAuthAndMetadataHeaders() throws InterruptedException {
+        // Given
+        httpClient = new GrayskullHttpClient(mockAuthProvider, config,
+                () -> "my-host.example");
+        Response<SecretValue> response = new Response<>(new SecretValue(1, "pub", "priv"), "Success");
+
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody(toJson(response))
+                .addHeader("Content-Type", "application/json"));
+
+        // When
+        httpClient.doPostWithRetry(
+                mockWebServer.url("/test").toString(),
+                "{}");
+
+        // Then
+        RecordedRequest request = mockWebServer.takeRequest(1, TimeUnit.SECONDS);
+        assertNotNull(request);
+        assertEquals("Bearer test-token", request.getHeader("Authorization"));
+        String version = request.getHeader("X-Grayskull-SDK-Version");
+        assertNotNull(version);
+        assertTrue(version.startsWith("java/"), "unexpected SDK version header: " + version);
+        assertEquals("my-host.example", request.getHeader("X-Grayskull-Host-Identification"));
+    }
+
+    @Test
+    void testDoPostWithRetry_retriesOnServerError() throws InterruptedException {
+        // Given
+        httpClient = new GrayskullHttpClient(mockAuthProvider, config);
+        Response<SecretValue> response = new Response<>(new SecretValue(1, "pub", "priv"), "Success");
+        String jsonResponse = toJson(response);
+
+        mockWebServer.enqueue(new MockResponse().setResponseCode(500).setBody("Internal Server Error"));
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody(jsonResponse)
+                .addHeader("Content-Type", "application/json"));
+
+        // When
+        HttpResponse result = httpClient.doPostWithRetry(
+                mockWebServer.url("/test").toString(),
+                "{}");
+
+        // Then
+        assertNotNull(result);
+        assertEquals(200, result.getStatusCode());
+        assertEquals(2, mockWebServer.getRequestCount());
+    }
+
+    @Test
+    void testDoPostWithRetry_noRetryOn4xx() {
+        // Given
+        httpClient = new GrayskullHttpClient(mockAuthProvider, config);
+        mockWebServer.enqueue(new MockResponse().setResponseCode(400).setBody("Bad Request"));
+
+        // When/Then
+        GrayskullException exception = assertThrows(GrayskullException.class, () ->
+                httpClient.doPostWithRetry(
+                        mockWebServer.url("/test").toString(),
+                        "{}"));
+
+        assertEquals(400, exception.getStatusCode());
+        assertEquals(1, mockWebServer.getRequestCount());
+    }
+
+    @Test
+    void testDoPostWithRetry_exhaustsRetries() {
+        // Given
+        httpClient = new GrayskullHttpClient(mockAuthProvider, config);
+        for (int i = 0; i < config.getMaxRetries(); i++) {
+            mockWebServer.enqueue(new MockResponse().setResponseCode(500).setBody("Error"));
+        }
+
+        // When/Then
+        GrayskullException exception = assertThrows(GrayskullException.class, () ->
+                httpClient.doPostWithRetry(
+                        mockWebServer.url("/test").toString(),
+                        "{}"));
+
+        assertTrue(exception.getMessage().contains("Failed after"));
+        assertEquals(config.getMaxRetries(), mockWebServer.getRequestCount());
+    }
+
+    @Test
+    void testDoGetWithRetry_includesMetadataHeaders() throws InterruptedException {
+        // Given
+        httpClient = new GrayskullHttpClient(mockAuthProvider, config,
+                () -> "host-42");
+        Response<SecretValue> response = new Response<>(new SecretValue(1, "pub", "priv"), "Success");
+
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody(toJson(response))
+                .addHeader("Content-Type", "application/json"));
+
+        // When
+        httpClient.doGetWithRetry(mockWebServer.url("/test").toString());
+
+        // Then
+        RecordedRequest request = mockWebServer.takeRequest(1, TimeUnit.SECONDS);
+        assertNotNull(request);
+        String version = request.getHeader("X-Grayskull-SDK-Version");
+        assertNotNull(version);
+        assertTrue(version.startsWith("java/"), "unexpected SDK version header: " + version);
+        assertEquals("host-42", request.getHeader("X-Grayskull-Host-Identification"));
+    }
+
+    @Test
+    void testHostIdentificationHeader_omittedWhenProviderReturnsBlank() throws InterruptedException {
+        httpClient = new GrayskullHttpClient(mockAuthProvider, config, () -> "");
+        Response<SecretValue> response = new Response<>(new SecretValue(1, "pub", "priv"), "Success");
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody(toJson(response))
+                .addHeader("Content-Type", "application/json"));
+
+        httpClient.doGetWithRetry(mockWebServer.url("/test").toString());
+
+        RecordedRequest request = mockWebServer.takeRequest(1, TimeUnit.SECONDS);
+        assertNotNull(request);
+        // Empty provider output => SDK omits the header entirely (server can
+        // distinguish "no identity" from a literal empty string).
+        assertNull(request.getHeader("X-Grayskull-Host-Identification"));
+    }
+
+    @Test
+    void testHostIdentificationHeader_sanitisesCrLfToSpaces() throws InterruptedException {
+        // Defensive: even though the SPI contract forbids CR/LF, the client
+        // sanitises them so a buggy provider can never enable header injection.
+        httpClient = new GrayskullHttpClient(mockAuthProvider, config,
+                () -> "bad\r\nInjected: true");
+        Response<SecretValue> response = new Response<>(new SecretValue(1, "pub", "priv"), "Success");
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody(toJson(response))
+                .addHeader("Content-Type", "application/json"));
+
+        httpClient.doGetWithRetry(mockWebServer.url("/test").toString());
+
+        RecordedRequest request = mockWebServer.takeRequest(1, TimeUnit.SECONDS);
+        assertNotNull(request);
+        String hostId = request.getHeader("X-Grayskull-Host-Identification");
+        assertNotNull(hostId);
+        assertFalse(hostId.contains("\r"));
+        assertFalse(hostId.contains("\n"));
+        // No "Injected" header smuggled through.
+        assertNull(request.getHeader("Injected"));
+    }
+
+    @Test
+    void testConstructor_rejectsNullHostIdentityProvider() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new GrayskullHttpClient(mockAuthProvider, config, null));
     }
 
     private String toJson(Object obj) {

--- a/clients/java/client-impl/src/test/java/com/flipkart/grayskull/SecretRefreshManagerTest.java
+++ b/clients/java/client-impl/src/test/java/com/flipkart/grayskull/SecretRefreshManagerTest.java
@@ -1,0 +1,418 @@
+package com.flipkart.grayskull;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import com.flipkart.grayskull.hooks.SecretRefreshHook;
+import com.flipkart.grayskull.models.SecretValue;
+import com.flipkart.grayskull.models.response.BatchGetSecretsResponse;
+import com.flipkart.grayskull.models.response.BatchSecretItem;
+import com.flipkart.grayskull.models.response.HttpResponse;
+import com.flipkart.grayskull.models.response.Response;
+
+@ExtendWith(MockitoExtension.class)
+class SecretRefreshManagerTest {
+
+    @Mock
+    private GrayskullHttpClient mockHttpClient;
+
+    private ObjectMapper objectMapper;
+    private SecretRefreshManager manager;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new ParameterNamesModule());
+        manager = new SecretRefreshManager(mockHttpClient, "http://localhost/v1/secrets/batch",
+                objectMapper, 30);
+    }
+
+    @Test
+    void register_addsHookAndReturnsUniqueIds() {
+        long id1 = manager.register("proj:s1", (s) -> {}, 1);
+        long id2 = manager.register("proj:s2", (s) -> {}, 1);
+        long id3 = manager.register("proj:s1", (s) -> {}, 1);
+
+        assertEquals(3, manager.hookCount());
+        assertEquals(2, manager.secretCount());
+        assertTrue(id1 > 0);
+        assertTrue(id2 != id1);
+        assertTrue(id3 != id2 && id3 != id1);
+    }
+
+    @Test
+    void poll_withNoHooks_doesNothing() {
+        manager.poll();
+        verifyNoInteractions(mockHttpClient);
+    }
+
+    @Test
+    void poll_callsServerAndInvokesHook_whenSecretUpdated() throws Exception {
+        AtomicReference<SecretValue> received = new AtomicReference<>();
+        SecretRefreshHook hook = received::set;
+        manager.register("proj-a:db-pass", hook, 1);
+
+        BatchSecretItem updated = new BatchSecretItem("proj-a", "db-pass", 2, "user", "newpass");
+        BatchGetSecretsResponse batchResponse = new BatchGetSecretsResponse(1, Collections.singletonList(updated));
+        Response<BatchGetSecretsResponse> response = new Response<>(batchResponse, "Success");
+        String json = objectMapper.writeValueAsString(response);
+
+        when(mockHttpClient.doPostWithRetry(anyString(), anyString()))
+                .thenReturn(new HttpResponse(200, json, "application/json", "http/1.1"));
+
+        manager.poll();
+
+        assertNotNull(received.get());
+        assertEquals(2, received.get().getDataVersion());
+        assertEquals("newpass", received.get().getPrivatePart());
+        verify(mockHttpClient).doPostWithRetry(eq("http://localhost/v1/secrets/batch"), anyString());
+    }
+
+    @Test
+    void poll_doesNotInvokeHook_whenNoUpdates() throws Exception {
+        AtomicInteger callCount = new AtomicInteger(0);
+        manager.register("proj:secret", (s) -> callCount.incrementAndGet(), 5);
+
+        BatchGetSecretsResponse batchResponse = new BatchGetSecretsResponse(0, Collections.emptyList());
+        Response<BatchGetSecretsResponse> response = new Response<>(batchResponse, "Success");
+        String json = objectMapper.writeValueAsString(response);
+
+        when(mockHttpClient.doPostWithRetry(anyString(), anyString()))
+                .thenReturn(new HttpResponse(200, json, "application/json", "http/1.1"));
+
+        manager.poll();
+
+        assertEquals(0, callCount.get());
+    }
+
+    @Test
+    void poll_handlesServerErrorGracefully() {
+        manager.register("proj:secret", (s) -> {}, 1);
+
+        when(mockHttpClient.doPostWithRetry(anyString(), anyString()))
+                .thenThrow(new RuntimeException("Server down"));
+
+        manager.poll();
+    }
+
+    @Test
+    void poll_handlesHookExceptionGracefully_forSeparateSecrets() throws Exception {
+        AtomicInteger secondHookCalls = new AtomicInteger(0);
+        manager.register("proj:secret-1", (s) -> { throw new RuntimeException("hook error"); }, 1);
+        manager.register("proj:secret-2", (s) -> secondHookCalls.incrementAndGet(), 1);
+
+        BatchSecretItem u1 = new BatchSecretItem("proj", "secret-1", 2, "pub1", "priv1");
+        BatchSecretItem u2 = new BatchSecretItem("proj", "secret-2", 3, "pub2", "priv2");
+        BatchGetSecretsResponse batchResponse = new BatchGetSecretsResponse(2, Arrays.asList(u1, u2));
+        Response<BatchGetSecretsResponse> response = new Response<>(batchResponse, "Success");
+        String json = objectMapper.writeValueAsString(response);
+
+        when(mockHttpClient.doPostWithRetry(anyString(), anyString()))
+                .thenReturn(new HttpResponse(200, json, "application/json", "http/1.1"));
+
+        manager.poll();
+
+        assertEquals(1, secondHookCalls.get());
+    }
+
+    @Test
+    void poll_handlesNullResponseData() throws Exception {
+        manager.register("proj:secret", (s) -> fail("should not be called"), 1);
+
+        Response<BatchGetSecretsResponse> response = new Response<>(null, "Success");
+        String json = objectMapper.writeValueAsString(response);
+
+        when(mockHttpClient.doPostWithRetry(anyString(), anyString()))
+                .thenReturn(new HttpResponse(200, json, "application/json", "http/1.1"));
+
+        manager.poll();
+    }
+
+    @Test
+    void poll_handlesNullUpdatedSecretsList() throws Exception {
+        manager.register("proj:secret", (s) -> fail("should not be called"), 1);
+
+        BatchGetSecretsResponse batchResponse = new BatchGetSecretsResponse(0, null);
+        Response<BatchGetSecretsResponse> response = new Response<>(batchResponse, "Success");
+        String json = objectMapper.writeValueAsString(response);
+
+        when(mockHttpClient.doPostWithRetry(anyString(), anyString()))
+                .thenReturn(new HttpResponse(200, json, "application/json", "http/1.1"));
+
+        manager.poll();
+    }
+
+    @Test
+    void shutdown_doesNotThrowWhenSchedulerNotStarted() {
+        manager.shutdown();
+    }
+
+    @Test
+    void shutdown_stopsRunningScheduler() {
+        // Starts the scheduler as a side effect.
+        manager.register("proj:secret", (s) -> {}, 1);
+        manager.shutdown();
+        // No exception; a second shutdown is also safe.
+        manager.shutdown();
+    }
+
+    @Test
+    void poll_multipleHooksPerSecret_areInvokedInRegistrationOrder_onUpdate() throws Exception {
+        List<String> order = new CopyOnWriteArrayList<>();
+        manager.register("proj:s", (v) -> order.add("A"), 1);
+        manager.register("proj:s", (v) -> order.add("B"), 1);
+        manager.register("proj:s", (v) -> order.add("C"), 1);
+
+        BatchSecretItem u = new BatchSecretItem("proj", "s", 2, "pub", "priv");
+        BatchGetSecretsResponse batch = new BatchGetSecretsResponse(1, Collections.singletonList(u));
+        String json = objectMapper.writeValueAsString(new Response<>(batch, "Success"));
+        when(mockHttpClient.doPostWithRetry(anyString(), anyString()))
+                .thenReturn(new HttpResponse(200, json, "application/json", "http/1.1"));
+
+        manager.poll();
+
+        assertEquals(Arrays.asList("A", "B", "C"), order);
+    }
+
+    @Test
+    void poll_firstHookThrowing_stillInvokesSubsequentHooksForSameSecret() throws Exception {
+        List<String> order = new CopyOnWriteArrayList<>();
+        manager.register("proj:s", (v) -> { order.add("A-threw"); throw new RuntimeException("boom"); }, 1);
+        manager.register("proj:s", (v) -> order.add("B"), 1);
+
+        BatchSecretItem u = new BatchSecretItem("proj", "s", 2, "pub", "priv");
+        String json = objectMapper.writeValueAsString(
+                new Response<>(new BatchGetSecretsResponse(1, Collections.singletonList(u)), "Success"));
+        when(mockHttpClient.doPostWithRetry(anyString(), anyString()))
+                .thenReturn(new HttpResponse(200, json, "application/json", "http/1.1"));
+
+        manager.poll();
+
+        assertEquals(Arrays.asList("A-threw", "B"), order);
+    }
+
+    @Test
+    void poll_lateRegisteredHookAtCurrentVersion_isNotReinvoked() throws Exception {
+        // Hook A registered at v1; hook B registered later at v2. Server says
+        // current version is 2 → only A should be invoked; B is already caught up.
+        AtomicInteger aCalls = new AtomicInteger(0);
+        AtomicInteger bCalls = new AtomicInteger(0);
+        manager.register("proj:s", (v) -> aCalls.incrementAndGet(), 1);
+        manager.register("proj:s", (v) -> bCalls.incrementAndGet(), 2);
+
+        BatchSecretItem u = new BatchSecretItem("proj", "s", 2, "pub", "priv");
+        String json = objectMapper.writeValueAsString(
+                new Response<>(new BatchGetSecretsResponse(1, Collections.singletonList(u)), "Success"));
+        when(mockHttpClient.doPostWithRetry(anyString(), anyString()))
+                .thenReturn(new HttpResponse(200, json, "application/json", "http/1.1"));
+
+        manager.poll();
+
+        assertEquals(1, aCalls.get());
+        assertEquals(0, bCalls.get());
+    }
+
+    @Test
+    void poll_hookThrowing_doesNotAdvanceLastKnownVersion_andIsRetriedNextPoll() throws Exception {
+        AtomicInteger attempts = new AtomicInteger(0);
+        manager.register("proj:s", (v) -> {
+            attempts.incrementAndGet();
+            throw new RuntimeException("flaky");
+        }, 1);
+
+        BatchSecretItem u = new BatchSecretItem("proj", "s", 2, "pub", "priv");
+        String json = objectMapper.writeValueAsString(
+                new Response<>(new BatchGetSecretsResponse(1, Collections.singletonList(u)), "Success"));
+        when(mockHttpClient.doPostWithRetry(anyString(), anyString()))
+                .thenReturn(new HttpResponse(200, json, "application/json", "http/1.1"));
+
+        manager.poll();
+        manager.poll();
+
+        // Hook retried both times because its lastKnownVersion did not advance.
+        assertEquals(2, attempts.get());
+    }
+
+    @Test
+    void poll_minLastKnownVersionIsSentToServer_whenHooksAtDifferentVersions() throws Exception {
+        manager.register("proj:s", (v) -> {}, 5);
+        manager.register("proj:s", (v) -> {}, 2);
+
+        when(mockHttpClient.doPostWithRetry(anyString(), anyString()))
+                .thenReturn(new HttpResponse(200,
+                        objectMapper.writeValueAsString(
+                                new Response<>(new BatchGetSecretsResponse(0, Collections.emptyList()), "Success")),
+                        "application/json", "http/1.1"));
+
+        manager.poll();
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockHttpClient).doPostWithRetry(anyString(), bodyCaptor.capture());
+        // Minimum across hooks for this secret is 2.
+        assertTrue(bodyCaptor.getValue().contains("\"lastKnownVersion\":2"),
+                "Expected min lastKnownVersion 2 in request, got: " + bodyCaptor.getValue());
+    }
+
+    @Test
+    void poll_respectsBatchSizeOf50() throws Exception {
+        // Register 75 secrets → expect 2 POSTs (50 + 25).
+        for (int i = 0; i < 75; i++) {
+            manager.register("proj:s" + i, (v) -> {}, 1);
+        }
+        when(mockHttpClient.doPostWithRetry(anyString(), anyString()))
+                .thenReturn(new HttpResponse(200,
+                        objectMapper.writeValueAsString(
+                                new Response<>(new BatchGetSecretsResponse(0, new ArrayList<>()), "Success")),
+                        "application/json", "http/1.1"));
+
+        manager.poll();
+
+        verify(mockHttpClient, times(2)).doPostWithRetry(anyString(), anyString());
+    }
+
+    @Test
+    void unregister_removesSingleHook_andLeavesSiblingHooksActive() throws Exception {
+        AtomicInteger aCalls = new AtomicInteger(0);
+        AtomicInteger bCalls = new AtomicInteger(0);
+        long idA = manager.register("proj:s", (v) -> aCalls.incrementAndGet(), 1);
+        manager.register("proj:s", (v) -> bCalls.incrementAndGet(), 1);
+
+        assertTrue(manager.unregister("proj:s", idA));
+        assertEquals(1, manager.hookCount());
+        assertEquals(1, manager.secretCount());
+
+        BatchSecretItem u = new BatchSecretItem("proj", "s", 2, "pub", "priv");
+        String json = objectMapper.writeValueAsString(
+                new Response<>(new BatchGetSecretsResponse(1, Collections.singletonList(u)), "Success"));
+        when(mockHttpClient.doPostWithRetry(anyString(), anyString()))
+                .thenReturn(new HttpResponse(200, json, "application/json", "http/1.1"));
+
+        manager.poll();
+
+        assertEquals(0, aCalls.get());
+        assertEquals(1, bCalls.get());
+    }
+
+    @Test
+    void unregister_whenLastHookRemoved_prunesSecretAndSkipsServerCall() {
+        long id = manager.register("proj:s", (v) -> {}, 1);
+        assertTrue(manager.unregister("proj:s", id));
+        assertEquals(0, manager.hookCount());
+        assertEquals(0, manager.secretCount());
+
+        manager.poll();
+        verify(mockHttpClient, never()).doPostWithRetry(anyString(), anyString());
+    }
+
+    @Test
+    void unregister_unknownSecret_returnsFalse() {
+        assertFalse(manager.unregister("unknown:secret", 999L));
+    }
+
+    @Test
+    void unregister_unknownHookId_returnsFalse() {
+        manager.register("proj:s", (v) -> {}, 1);
+        assertFalse(manager.unregister("proj:s", 99999L));
+        // Existing hook unaffected.
+        assertEquals(1, manager.hookCount());
+    }
+
+    @Test
+    void poll_skipsMalformedSecretRefs_ratherThanFailingBatch() throws Exception {
+        // A single-token "badref" should never be accepted by the client layer,
+        // but the manager guards against it anyway so one bad entry doesn't
+        // poison the rest of the batch.
+        manager.register("badref", (v) -> {}, 1);
+        manager.register("proj:good", (v) -> {}, 1);
+
+        when(mockHttpClient.doPostWithRetry(anyString(), anyString()))
+                .thenReturn(new HttpResponse(200,
+                        objectMapper.writeValueAsString(
+                                new Response<>(new BatchGetSecretsResponse(0, Collections.emptyList()), "Success")),
+                        "application/json", "http/1.1"));
+
+        manager.poll();
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockHttpClient).doPostWithRetry(anyString(), bodyCaptor.capture());
+        // Good secret is present; malformed one is dropped.
+        assertTrue(bodyCaptor.getValue().contains("\"secretName\":\"good\""));
+        assertFalse(bodyCaptor.getValue().contains("badref"));
+    }
+
+    @Test
+    void poll_skipsEntirelyWhenBatchContainsOnlyMalformedRefs() {
+        manager.register("badref", (v) -> {}, 1);
+
+        manager.poll();
+
+        // No valid entries → no HTTP call made at all.
+        verify(mockHttpClient, never()).doPostWithRetry(anyString(), anyString());
+    }
+
+    @Test
+    void poll_updatedSecretWithNoRegisteredHooks_isIgnored() throws Exception {
+        // Server returns an update for a secret we no longer track (e.g. raced
+        // with unregister). Manager must skip cleanly.
+        long id = manager.register("proj:s", (v) -> fail("should not be called"), 1);
+        manager.unregister("proj:s", id);
+
+        // Re-register a DIFFERENT secret so the poll actually fires.
+        AtomicInteger otherCalls = new AtomicInteger(0);
+        manager.register("proj:other", (v) -> otherCalls.incrementAndGet(), 1);
+
+        BatchSecretItem stale = new BatchSecretItem("proj", "s", 2, "pub", "priv");
+        BatchSecretItem current = new BatchSecretItem("proj", "other", 2, "pub", "priv");
+        String json = objectMapper.writeValueAsString(
+                new Response<>(new BatchGetSecretsResponse(2, Arrays.asList(stale, current)), "Success"));
+        when(mockHttpClient.doPostWithRetry(anyString(), anyString()))
+                .thenReturn(new HttpResponse(200, json, "application/json", "http/1.1"));
+
+        manager.poll();
+        assertEquals(1, otherCalls.get());
+    }
+
+    @Test
+    void poll_urlAndPayloadStructure_isCorrect() throws Exception {
+        manager.register("proj-x:k1", (v) -> {}, 7);
+
+        when(mockHttpClient.doPostWithRetry(anyString(), anyString()))
+                .thenReturn(new HttpResponse(200,
+                        objectMapper.writeValueAsString(
+                                new Response<>(new BatchGetSecretsResponse(0, Collections.emptyList()), "Success")),
+                        "application/json", "http/1.1"));
+
+        manager.poll();
+        verify(mockHttpClient).doPostWithRetry(
+                eq("http://localhost/v1/secrets/batch"),
+                contains("\"projectId\":\"proj-x\""));
+    }
+}

--- a/clients/java/client-impl/src/test/java/com/flipkart/grayskull/hooks/ActiveRefreshHandlerRefTest.java
+++ b/clients/java/client-impl/src/test/java/com/flipkart/grayskull/hooks/ActiveRefreshHandlerRefTest.java
@@ -1,0 +1,92 @@
+package com.flipkart.grayskull.hooks;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.flipkart.grayskull.SecretRefreshManager;
+
+@ExtendWith(MockitoExtension.class)
+class ActiveRefreshHandlerRefTest {
+
+    @Mock
+    private SecretRefreshManager manager;
+
+    @Test
+    void getSecretRef_returnsCorrectRef() {
+        ActiveRefreshHandlerRef ref = new ActiveRefreshHandlerRef("proj:secret", 1L, manager);
+        assertEquals("proj:secret", ref.getSecretRef());
+    }
+
+    @Test
+    void isActive_returnsTrueAfterConstruction() {
+        ActiveRefreshHandlerRef ref = new ActiveRefreshHandlerRef("proj:secret", 7L, manager);
+        assertTrue(ref.isActive());
+    }
+
+    @Test
+    void unRegister_callsManagerAndDeactivates() {
+        when(manager.unregister("proj:secret", 42L)).thenReturn(true);
+        ActiveRefreshHandlerRef ref = new ActiveRefreshHandlerRef("proj:secret", 42L, manager);
+
+        ref.unRegister();
+
+        assertFalse(ref.isActive());
+        verify(manager, times(1)).unregister("proj:secret", 42L);
+    }
+
+    @Test
+    void unRegister_isIdempotent_onlyCallsManagerOnce() {
+        when(manager.unregister("proj:secret", 42L)).thenReturn(true);
+        ActiveRefreshHandlerRef ref = new ActiveRefreshHandlerRef("proj:secret", 42L, manager);
+
+        ref.unRegister();
+        ref.unRegister();
+        ref.unRegister();
+
+        assertFalse(ref.isActive());
+        verify(manager, times(1)).unregister("proj:secret", 42L);
+    }
+
+    @Test
+    void unRegister_handlesManagerReturningFalse() {
+        // If manager says "nothing removed" we still deactivate and never retry.
+        when(manager.unregister("proj:secret", 42L)).thenReturn(false);
+        ActiveRefreshHandlerRef ref = new ActiveRefreshHandlerRef("proj:secret", 42L, manager);
+
+        ref.unRegister();
+
+        assertFalse(ref.isActive());
+        verify(manager, times(1)).unregister("proj:secret", 42L);
+    }
+
+    @Test
+    void constructor_rejectsNullSecretRef() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new ActiveRefreshHandlerRef(null, 1L, manager));
+        verifyNoInteractions(manager);
+    }
+
+    @Test
+    void constructor_rejectsEmptySecretRef() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new ActiveRefreshHandlerRef("", 1L, manager));
+        verifyNoInteractions(manager);
+    }
+
+    @Test
+    void constructor_rejectsNullManager() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new ActiveRefreshHandlerRef("proj:secret", 1L, null));
+    }
+}

--- a/clients/java/client-impl/src/test/java/com/flipkart/grayskull/models/GrayskullClientConfigurationTest.java
+++ b/clients/java/client-impl/src/test/java/com/flipkart/grayskull/models/GrayskullClientConfigurationTest.java
@@ -1,0 +1,34 @@
+package com.flipkart.grayskull.models;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GrayskullClientConfigurationTest {
+
+    @Test
+    void pollIntervalSeconds_defaultIs30() {
+        GrayskullClientConfiguration config = new GrayskullClientConfiguration();
+        assertEquals(30, config.getPollIntervalSeconds());
+    }
+
+    @Test
+    void setPollIntervalSeconds_valid() {
+        GrayskullClientConfiguration config = new GrayskullClientConfiguration();
+        config.setPollIntervalSeconds(60);
+        assertEquals(60, config.getPollIntervalSeconds());
+    }
+
+    @Test
+    void setPollIntervalSeconds_minimum() {
+        GrayskullClientConfiguration config = new GrayskullClientConfiguration();
+        config.setPollIntervalSeconds(10);
+        assertEquals(10, config.getPollIntervalSeconds());
+    }
+
+    @Test
+    void setPollIntervalSeconds_belowMinimum_throws() {
+        GrayskullClientConfiguration config = new GrayskullClientConfiguration();
+        assertThrows(IllegalArgumentException.class, () -> config.setPollIntervalSeconds(9));
+    }
+}

--- a/clients/java/client-impl/src/test/java/com/flipkart/grayskull/spi/DefaultHostIdentityProviderTest.java
+++ b/clients/java/client-impl/src/test/java/com/flipkart/grayskull/spi/DefaultHostIdentityProviderTest.java
@@ -1,0 +1,62 @@
+package com.flipkart.grayskull.spi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class DefaultHostIdentityProviderTest {
+
+    @Test
+    void getHostIdentification_returnsNonBlankValue() {
+        DefaultHostIdentityProvider p = new DefaultHostIdentityProvider();
+        String id = p.getHostIdentification();
+
+        assertNotNull(id);
+        assertFalse(id.isEmpty());
+        // Either it's a real hostname, or the deterministic fallback sentinel.
+        // In both cases the value MUST be trimmed (no surrounding whitespace).
+        assertEquals(id.trim(), id);
+    }
+
+    @Test
+    void getHostIdentification_isStableAcrossCalls() {
+        DefaultHostIdentityProvider p = new DefaultHostIdentityProvider();
+        assertEquals(p.getHostIdentification(), p.getHostIdentification());
+    }
+
+    @Test
+    void fallbackSentinel_whenResolverThrows() {
+        DefaultHostIdentityProvider p = new DefaultHostIdentityProvider(
+                () -> { throw new java.net.UnknownHostException("forced"); });
+        assertEquals("unknown-host", p.getHostIdentification());
+    }
+
+    @Test
+    void fallbackSentinel_whenResolverReturnsNull() {
+        DefaultHostIdentityProvider p = new DefaultHostIdentityProvider(() -> null);
+        assertEquals("unknown-host", p.getHostIdentification());
+    }
+
+    @Test
+    void fallbackSentinel_whenResolverReturnsBlank() {
+        DefaultHostIdentityProvider p = new DefaultHostIdentityProvider(() -> "   ");
+        assertEquals("unknown-host", p.getHostIdentification());
+    }
+
+    @Test
+    void resolverValue_isTrimmed() {
+        DefaultHostIdentityProvider p = new DefaultHostIdentityProvider(() -> "  my-host  ");
+        assertEquals("my-host", p.getHostIdentification());
+    }
+
+    @Test
+    void sanityCheck_defaultConstructorExercisesRealResolver() {
+        // Ensures coverage of the no-arg constructor path which resolves via
+        // InetAddress.getLocalHost() (or its fallback) in the real environment.
+        DefaultHostIdentityProvider p = new DefaultHostIdentityProvider();
+        assertTrue(p.getHostIdentification() != null && !p.getHostIdentification().isEmpty());
+    }
+}

--- a/clients/java/client-impl/src/test/java/com/flipkart/grayskull/spi/SdkVersionTest.java
+++ b/clients/java/client-impl/src/test/java/com/flipkart/grayskull/spi/SdkVersionTest.java
@@ -1,0 +1,135 @@
+package com.flipkart.grayskull.spi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Enumeration;
+
+import org.junit.jupiter.api.Test;
+
+class SdkVersionTest {
+
+    @Test
+    void get_isNonNullAndPrefixed() {
+        String v = SdkVersion.get();
+        assertNotNull(v);
+        assertTrue(v.startsWith("java/"), "Expected 'java/<version>' prefix, got: " + v);
+    }
+
+    @Test
+    void get_isStable() {
+        // Version is resolved once at class load; subsequent calls must be identical.
+        assertEquals(SdkVersion.get(), SdkVersion.get());
+    }
+
+    @Test
+    void get_isNotLiteralPlaceholder() {
+        // If Maven resource filtering ran correctly, the version must not be
+        // the literal ${project.version} placeholder.
+        assertTrue(!SdkVersion.get().contains("${"),
+                "SDK version looks unfiltered: " + SdkVersion.get());
+    }
+
+    @Test
+    void get_isEitherResolvedOrFallbackSentinel() {
+        // In a proper build the version will be "java/<semver>". When running
+        // directly from a classpath that has not been filtered (very unusual
+        // in CI) the fallback sentinel is acceptable.
+        String v = SdkVersion.get();
+        assertTrue(v.matches("^java/(unknown|[\\w\\-.]+)$"),
+                "Unexpected version format: " + v);
+    }
+
+    @Test
+    void parseVersion_nullStream_returnsUnknown() throws IOException {
+        assertEquals(SdkVersion.UNKNOWN, SdkVersion.parseVersion(null));
+    }
+
+    @Test
+    void parseVersion_missingVersionKey_returnsUnknown() throws IOException {
+        try (InputStream in = SdkVersion.propertiesStream("other=1.0\n")) {
+            assertEquals(SdkVersion.UNKNOWN, SdkVersion.parseVersion(in));
+        }
+    }
+
+    @Test
+    void parseVersion_blankVersion_returnsUnknown() throws IOException {
+        try (InputStream in = SdkVersion.propertiesStream("version=   \n")) {
+            assertEquals(SdkVersion.UNKNOWN, SdkVersion.parseVersion(in));
+        }
+    }
+
+    @Test
+    void parseVersion_unfilteredPlaceholder_returnsUnknown() throws IOException {
+        try (InputStream in = SdkVersion.propertiesStream("version=${project.version}\n")) {
+            assertEquals(SdkVersion.UNKNOWN, SdkVersion.parseVersion(in));
+        }
+    }
+
+    @Test
+    void parseVersion_validVersion_returnsPrefixedValue() throws IOException {
+        try (InputStream in = SdkVersion.propertiesStream("version=9.9.9\n")) {
+            assertEquals("java/9.9.9", SdkVersion.parseVersion(in));
+        }
+    }
+
+    @Test
+    void parseVersion_valueIsTrimmed() throws IOException {
+        try (InputStream in = SdkVersion.propertiesStream("version=  1.2.3  \n")) {
+            assertEquals("java/1.2.3", SdkVersion.parseVersion(in));
+        }
+    }
+
+    @Test
+    void loadFromClassLoader_null_returnsUnknown() {
+        assertEquals(SdkVersion.UNKNOWN, SdkVersion.loadFromClassLoader(null));
+    }
+
+    @Test
+    void loadFromClassLoader_missingResource_returnsUnknown() {
+        ClassLoader alwaysNull = new ClassLoader(null) {
+            @Override
+            public InputStream getResourceAsStream(String name) {
+                return null;
+            }
+        };
+        assertEquals(SdkVersion.UNKNOWN, SdkVersion.loadFromClassLoader(alwaysNull));
+    }
+
+    @Test
+    void loadFromClassLoader_resourceIOError_returnsUnknown() {
+        ClassLoader brokenStream = new ClassLoader(null) {
+            @Override
+            public InputStream getResourceAsStream(String name) {
+                return new InputStream() {
+                    @Override
+                    public int read() throws IOException {
+                        throw new IOException("forced");
+                    }
+                };
+            }
+
+            @Override
+            public Enumeration<URL> getResources(String name) {
+                return Collections.emptyEnumeration();
+            }
+        };
+        assertEquals(SdkVersion.UNKNOWN, SdkVersion.loadFromClassLoader(brokenStream));
+    }
+
+    @Test
+    void loadFromClassLoader_validResource_returnsPrefixedValue() {
+        ClassLoader good = new ClassLoader(null) {
+            @Override
+            public InputStream getResourceAsStream(String name) {
+                return SdkVersion.propertiesStream("version=1.2.3-TEST\n");
+            }
+        };
+        assertEquals("java/1.2.3-TEST", SdkVersion.loadFromClassLoader(good));
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Active secret refresh with periodic polling support; refresh hooks now execute immediately upon registration and receive updates via background polling (configurable interval, default 30 seconds, minimum 10 seconds).
  - Customizable host identity provider support to attach identification headers to outbound requests.
  - Improved refresh hook lifecycle with proper registration and unregistration management.

* **Configuration**
  - Added `pollIntervalSeconds` setting to control secret refresh polling frequency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->