### PR TITLE
stopping read audits for pg nfrs

### DIFF
--- a/server/src/main/java/com/flipkart/grayskull/controllers/SecretBatchController.java
+++ b/server/src/main/java/com/flipkart/grayskull/controllers/SecretBatchController.java
@@ -71,7 +71,7 @@ public class SecretBatchController {
                     .metadata(metadata)
                     .build();
 
-            asyncAuditLogger.log(auditEntry);
+//            asyncAuditLogger.log(auditEntry);
         }
     }
 }

--- a/server/src/main/java/com/flipkart/grayskull/controllers/SecretController.java
+++ b/server/src/main/java/com/flipkart/grayskull/controllers/SecretController.java
@@ -99,7 +99,7 @@ public class SecretController {
                 .actorId(actorName)
                 .ips(requestUtils.getRemoteIPs())
                 .metadata(auditMetadata).build();
-        asyncAuditLogger.log(auditEntry);
+//        asyncAuditLogger.log(auditEntry);
         return ResponseTemplate.success(response, "Successfully read secret value.");
     }
 

--- a/server/src/main/java/com/flipkart/grayskull/spimpl/repositories/SecretRepositoryImpl.java
+++ b/server/src/main/java/com/flipkart/grayskull/spimpl/repositories/SecretRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.flipkart.grayskull.spi.models.enums.LifecycleState;
 import com.flipkart.grayskull.spi.repositories.SecretRepository;
 import com.flipkart.grayskull.spimpl.repositories.mongo.SecretDataMongoRepository;
 import com.flipkart.grayskull.spimpl.repositories.mongo.SecretMongoRepository;
+import io.micrometer.core.annotation.Timed;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -64,6 +65,11 @@ public class SecretRepositoryImpl implements SecretRepository {
     }
 
     @Override
+    @Timed(value = "spring.data.repository.invocations", extraTags = {
+            "method", "findActiveByProjectAndNames",
+            "repository", "SecretRepositoryImpl",
+            "state", "SUCCESS"
+    })
     public List<Secret> findActiveByProjectAndNames(Map<String, List<String>> projectToNames) {
         Query query = buildActiveSecretsQuery(projectToNames);
         if (query == null) {

--- a/server/src/test/java/com/flipkart/grayskull/controllers/SecretBatchControllerTest.java
+++ b/server/src/test/java/com/flipkart/grayskull/controllers/SecretBatchControllerTest.java
@@ -66,18 +66,18 @@ class SecretBatchControllerTest {
 
         assertThat(result.getData().getUpdatedCount()).isEqualTo(1);
 
-        ArgumentCaptor<AuditEntry> captor = ArgumentCaptor.captor();
-        verify(asyncAuditLogger).log(captor.capture());
-        AuditEntry logged = captor.getValue();
-        assertThat(logged.getProjectId()).isEqualTo("proj-b");
-        assertThat(logged.getResourceType()).isEqualTo(AuditConstants.RESOURCE_TYPE_SECRET);
-        assertThat(logged.getResourceName()).isEqualTo("api-key");
-        assertThat(logged.getResourceVersion()).isEqualTo(3);
-        assertThat(logged.getAction()).isEqualTo(AuditAction.BATCH_GET_SECRETS.name());
-        assertThat(logged.getUserId()).isEqualTo("user");
-        assertThat(logged.getActorId()).isEqualTo("actor-name");
-        assertThat(logged.getIps()).isEqualTo(expectedIps);
-        assertThat(logged.getMetadata()).containsEntry("publicPart", "pub");
+//        ArgumentCaptor<AuditEntry> captor = ArgumentCaptor.captor();
+//        verify(asyncAuditLogger).log(captor.capture());
+//        AuditEntry logged = captor.getValue();
+//        assertThat(logged.getProjectId()).isEqualTo("proj-b");
+//        assertThat(logged.getResourceType()).isEqualTo(AuditConstants.RESOURCE_TYPE_SECRET);
+//        assertThat(logged.getResourceName()).isEqualTo("api-key");
+//        assertThat(logged.getResourceVersion()).isEqualTo(3);
+//        assertThat(logged.getAction()).isEqualTo(AuditAction.BATCH_GET_SECRETS.name());
+//        assertThat(logged.getUserId()).isEqualTo("user");
+//        assertThat(logged.getActorId()).isEqualTo("actor-name");
+//        assertThat(logged.getIps()).isEqualTo(expectedIps);
+//        assertThat(logged.getMetadata()).containsEntry("publicPart", "pub");
     }
 
     @Test
@@ -112,21 +112,21 @@ class SecretBatchControllerTest {
 
         controller.batchGetSecrets(request);
 
-        ArgumentCaptor<AuditEntry> captor = ArgumentCaptor.captor();
-        verify(asyncAuditLogger, times(2)).log(captor.capture());
-
-        AuditEntry first = captor.getAllValues().get(0);
-        assertThat(first.getProjectId()).isEqualTo("proj-a");
-        assertThat(first.getResourceName()).isEqualTo("db-pass");
-        assertThat(first.getResourceVersion()).isEqualTo(2);
-        assertThat(first.getAction()).isEqualTo(AuditAction.BATCH_GET_SECRETS.name());
-        assertThat(first.getMetadata()).containsEntry("publicPart", "pub1");
-
-        AuditEntry second = captor.getAllValues().get(1);
-        assertThat(second.getProjectId()).isEqualTo("proj-b");
-        assertThat(second.getResourceName()).isEqualTo("api-key");
-        assertThat(second.getResourceVersion()).isEqualTo(3);
-        assertThat(second.getMetadata()).containsEntry("publicPart", "pub2");
+//        ArgumentCaptor<AuditEntry> captor = ArgumentCaptor.captor();
+//        verify(asyncAuditLogger, times(2)).log(captor.capture());
+//
+//        AuditEntry first = captor.getAllValues().get(0);
+//        assertThat(first.getProjectId()).isEqualTo("proj-a");
+//        assertThat(first.getResourceName()).isEqualTo("db-pass");
+//        assertThat(first.getResourceVersion()).isEqualTo(2);
+//        assertThat(first.getAction()).isEqualTo(AuditAction.BATCH_GET_SECRETS.name());
+//        assertThat(first.getMetadata()).containsEntry("publicPart", "pub1");
+//
+//        AuditEntry second = captor.getAllValues().get(1);
+//        assertThat(second.getProjectId()).isEqualTo("proj-b");
+//        assertThat(second.getResourceName()).isEqualTo("api-key");
+//        assertThat(second.getResourceVersion()).isEqualTo(3);
+//        assertThat(second.getMetadata()).containsEntry("publicPart", "pub2");
     }
 
     @Test
@@ -144,12 +144,12 @@ class SecretBatchControllerTest {
         when(requestUtils.getRemoteIPs()).thenReturn(Map.of());
 
         controller.batchGetSecrets(request);
-
-        ArgumentCaptor<AuditEntry> captor = ArgumentCaptor.captor();
-        verify(asyncAuditLogger).log(captor.capture());
-        assertThat(captor.getValue().getMetadata())
-                .containsEntry("RequestId", "req-123")
-                .containsEntry("publicPart", "pub");
+//
+//        ArgumentCaptor<AuditEntry> captor = ArgumentCaptor.captor();
+//        verify(asyncAuditLogger).log(captor.capture());
+//        assertThat(captor.getValue().getMetadata())
+//                .containsEntry("RequestId", "req-123")
+//                .containsEntry("publicPart", "pub");
     }
 
     @Test
@@ -168,10 +168,10 @@ class SecretBatchControllerTest {
 
         controller.batchGetSecrets(request);
 
-        ArgumentCaptor<AuditEntry> captor = ArgumentCaptor.captor();
-        verify(asyncAuditLogger).log(captor.capture());
-        assertThat(captor.getValue().getMetadata()).containsKey("publicPart");
-        assertThat(captor.getValue().getMetadata()).doesNotContainKey("RequestId");
+//        ArgumentCaptor<AuditEntry> captor = ArgumentCaptor.captor();
+//        verify(asyncAuditLogger).log(captor.capture());
+//        assertThat(captor.getValue().getMetadata()).containsKey("publicPart");
+//        assertThat(captor.getValue().getMetadata()).doesNotContainKey("RequestId");
     }
 
     @Test
@@ -192,13 +192,13 @@ class SecretBatchControllerTest {
 
         controller.batchGetSecrets(request);
 
-        ArgumentCaptor<AuditEntry> captor = ArgumentCaptor.captor();
-        verify(asyncAuditLogger, times(2)).log(captor.capture());
-        // Same RequestId on every entry (correlation) ...
-        assertThat(captor.getAllValues().get(0).getMetadata()).containsEntry("RequestId", "req-xyz");
-        assertThat(captor.getAllValues().get(1).getMetadata()).containsEntry("RequestId", "req-xyz");
-        // ... but each entry carries only its own publicPart.
-        assertThat(captor.getAllValues().get(0).getMetadata()).containsEntry("publicPart", "pubA");
-        assertThat(captor.getAllValues().get(1).getMetadata()).containsEntry("publicPart", "pubB");
+//        ArgumentCaptor<AuditEntry> captor = ArgumentCaptor.captor();
+//        verify(asyncAuditLogger, times(2)).log(captor.capture());
+//        // Same RequestId on every entry (correlation) ...
+//        assertThat(captor.getAllValues().get(0).getMetadata()).containsEntry("RequestId", "req-xyz");
+//        assertThat(captor.getAllValues().get(1).getMetadata()).containsEntry("RequestId", "req-xyz");
+//        // ... but each entry carries only its own publicPart.
+//        assertThat(captor.getAllValues().get(0).getMetadata()).containsEntry("publicPart", "pubA");
+//        assertThat(captor.getAllValues().get(1).getMetadata()).containsEntry("publicPart", "pubB");
     }
 }

--- a/server/src/test/java/com/flipkart/grayskull/controllers/SecretControllerTest.java
+++ b/server/src/test/java/com/flipkart/grayskull/controllers/SecretControllerTest.java
@@ -72,14 +72,14 @@ class SecretControllerTest {
         assertThat(result.getData()).isEqualTo(expectedResponse);
 
         // Verify audit logging
-        ArgumentCaptor<AuditEntry> auditEntryArgumentCaptor = ArgumentCaptor.captor();
+//        ArgumentCaptor<AuditEntry> auditEntryArgumentCaptor = ArgumentCaptor.captor();
 //        verify(asyncAuditLogger).log(auditEntryArgumentCaptor.capture());
-        Map<String, String> expectedAuditMetadata = new HashMap<>();
-        expectedAuditMetadata.put("publicPart", publicPart);
-        assertThat(auditEntryArgumentCaptor.getValue())
-                .usingRecursiveComparison()
-                .ignoringFields("timestamp")
-                .isEqualTo(new AuditEntry(null, PROJECT_ID, AuditConstants.RESOURCE_TYPE_SECRET, SECRET_NAME, 5, AuditAction.READ_SECRET.name(), "user", "actor-name", expectedIps, null, expectedAuditMetadata));
+//        Map<String, String> expectedAuditMetadata = new HashMap<>();
+//        expectedAuditMetadata.put("publicPart", publicPart);
+//        assertThat(auditEntryArgumentCaptor.getValue())
+//                .usingRecursiveComparison()
+//                .ignoringFields("timestamp")
+//                .isEqualTo(new AuditEntry(null, PROJECT_ID, AuditConstants.RESOURCE_TYPE_SECRET, SECRET_NAME, 5, AuditAction.READ_SECRET.name(), "user", "actor-name", expectedIps, null, expectedAuditMetadata));
     }
 
     @ParameterizedTest

--- a/server/src/test/java/com/flipkart/grayskull/controllers/SecretControllerTest.java
+++ b/server/src/test/java/com/flipkart/grayskull/controllers/SecretControllerTest.java
@@ -73,7 +73,7 @@ class SecretControllerTest {
 
         // Verify audit logging
         ArgumentCaptor<AuditEntry> auditEntryArgumentCaptor = ArgumentCaptor.captor();
-        verify(asyncAuditLogger).log(auditEntryArgumentCaptor.capture());
+//        verify(asyncAuditLogger).log(auditEntryArgumentCaptor.capture());
         Map<String, String> expectedAuditMetadata = new HashMap<>();
         expectedAuditMetadata.put("publicPart", publicPart);
         assertThat(auditEntryArgumentCaptor.getValue())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added performance metrics collection for repository method invocations with detailed tracking information.

* **Tests**
  * Disabled audit logging assertion verification in batch secret retrieval and secret read operation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->